### PR TITLE
Allow running without decodeable debug info

### DIFF
--- a/core/elf.ml
+++ b/core/elf.ml
@@ -41,9 +41,19 @@ let create filename =
       let statically_mappable = is_non_pie_executable header in
       let debug = Owee_elf.find_section_body buf sections ~section_name:".debug_line" in
       Some { string; symbol; debug; base_offset; filename; statically_mappable }
-    | _, _ -> None
+    | _, _ ->
+      Core.eprintf
+        "[Unable to find string or symbol table, will be unable to trigger on specific \
+         symbol. Was the binary built without debug info?]\n\
+         %!";
+      None
   with
-  | Owee_buf.Invalid_format _ -> None
+  | Owee_buf.Invalid_format _ ->
+    Core.eprintf
+      "[Invalid or unknown debug info format, will be unable to trigger on specific \
+       symbol.]\n\
+       %!";
+      None
 ;;
 
 let is_func sym =

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -54,7 +54,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
 
   type hits_file = (string * Breakpoint.Hit.t) list [@@deriving sexp]
 
-  let decode_to_trace { output_config; decode_opts; verbose } ~record_dir elf =
+  let decode_to_trace ?elf ~record_dir { output_config; decode_opts; verbose } =
     Core.eprintf "[Decoding, this may take 30s or so...]\n%!";
     Tracing_tool_output.write_and_view
       output_config
@@ -66,10 +66,10 @@ module Make_commands (Backend : Backend_intf.S) = struct
           |> Sexp.of_string
           |> [%of_sexp: hits_file]
         in
-        let debug_info = Elf.addr_table elf in
+        let debug_info = Option.map elf ~f:Elf.addr_table in
         let%bind event_pipe = Backend.decode_events decode_opts ~record_dir in
         let%bind () =
-          write_trace_from_events ~verbose ~debug_info trace_writer hits event_pipe
+          write_trace_from_events ?debug_info ~verbose trace_writer hits event_pipe
           |> Deferred.ok
         in
         Tracing.Trace.close trace_writer;
@@ -94,22 +94,28 @@ module Make_commands (Backend : Backend_intf.S) = struct
     ; finalize_recording : unit -> unit
     }
 
-  let attach opts elf pid =
+  let attach ?elf opts pid =
     let%bind.Deferred.Or_error () =
       check_for_processor_trace_support () |> Deferred.return
     in
-    let snap_syms = Elf.matching_functions elf opts.snap_symbol in
-    let%bind.Deferred.Or_error snap_sym =
-      match Map.length snap_syms, Map.min_elt snap_syms with
-      | 0, _ -> Deferred.Or_error.return None
-      | 1, Some (_, s) -> Deferred.Or_error.return (Some s)
-      | _ -> Fzf.pick_one (Fzf.Pick_from.Map snap_syms)
-    in
-    let snap_loc = Option.map snap_sym ~f:(fun sym -> Elf.symbol_stop_info elf pid sym) in
-    let filter =
-      match opts.use_filter, snap_loc with
-      | true, Some { Elf.Stop_info.filter; _ } -> Some filter
-      | _, _ -> None
+    let%bind.Deferred.Or_error filter, snap_loc =
+      match elf with
+      | None -> Deferred.Or_error.return (None, None)
+      | Some elf ->
+        let snap_syms = Elf.matching_functions elf opts.snap_symbol in
+        let%bind.Deferred.Or_error snap_sym =
+          match Map.length snap_syms, Map.min_elt snap_syms with
+          | 0, _ -> Deferred.Or_error.return None
+          | 1, Some (_, s) -> Deferred.Or_error.return (Some s)
+          | _ -> Fzf.pick_one (Fzf.Pick_from.Map snap_syms)
+        in
+        let snap_loc = Option.map snap_sym ~f:(fun sym -> Elf.symbol_stop_info elf pid sym) in
+        let filter =
+          match opts.use_filter, snap_loc with
+          | true, Some { Elf.Stop_info.filter; _ } -> Some filter
+          | _, _ -> None
+        in
+        Deferred.Or_error.return (filter, snap_loc)
     in
     let%map.Deferred.Or_error recording =
       Backend.attach_and_record opts.backend_opts ~record_dir:opts.record_dir ?filter pid
@@ -229,18 +235,18 @@ module Make_commands (Backend : Backend_intf.S) = struct
     Backend.finish_recording recording
   ;;
 
-  let run_and_record record_opts elf ~command =
+  let run_and_record ?elf ~command record_opts =
     let open Deferred.Or_error.Let_syntax in
     let argv = Array.of_list command in
     let pid = Probes_lib.Raw_ptrace.start ~argv |> Pid.of_int in
-    let%bind attachment = attach record_opts elf pid in
+    let%bind attachment = attach ?elf record_opts pid in
     Probes_lib.Raw_ptrace.detach (Pid.to_int pid);
     let%bind.Deferred (_ : Core_unix.Exit_or_signal.t) = Async_unix.Unix.waitpid pid in
     detach attachment
   ;;
 
-  let attach_and_record record_opts elf pid =
-    let%bind.Deferred.Or_error attachment = attach record_opts elf pid in
+  let attach_and_record ?elf record_opts pid =
+    let%bind.Deferred.Or_error attachment = attach ?elf record_opts pid in
     let { done_ivar; _ } = attachment in
     let stop = Ivar.read done_ivar in
     Async_unix.Signal.handle ~stop [ Signal.int ] ~f:(fun (_ : Signal.t) ->
@@ -365,11 +371,9 @@ module Make_commands (Backend : Backend_intf.S) = struct
            | None -> failwithf "Can't find executable for %s" cmd ()
          in
          record_opt_fn ~default_executable ~f:(fun opts ->
-             let elf =
-               Elf.create opts.executable |> Option.value_exn ~message:"Invalid ELF"
-             in
-             let%bind () = run_and_record opts elf ~command in
-             decode_to_trace decode_opts ~record_dir:opts.record_dir elf))
+             let elf = Elf.create opts.executable in
+             let%bind () = run_and_record ?elf ~command opts in
+             decode_to_trace ?elf ~record_dir:opts.record_dir decode_opts))
   ;;
 
   let select_pid () =
@@ -417,9 +421,9 @@ module Make_commands (Backend : Backend_intf.S) = struct
            Core_unix.readlink [%string "/proc/%{pid#Pid}/exe"]
          in
          record_opt_fn ~default_executable ~f:(fun opts ->
-             let elf = Elf.create opts.executable |> Option.value_exn in
-             let%bind () = attach_and_record opts elf pid in
-             decode_to_trace decode_opts ~record_dir:opts.record_dir elf))
+             let elf = Elf.create opts.executable in
+             let%bind () = attach_and_record ?elf opts pid in
+             decode_to_trace ?elf ~record_dir:opts.record_dir decode_opts))
   ;;
 
   let decode_command =
@@ -435,8 +439,8 @@ module Make_commands (Backend : Backend_intf.S) = struct
            ~doc:"FILE executable to extract information from"
        in
        fun () ->
-         let elf = Elf.create executable |> Option.value_exn in
-         decode_to_trace decode_opts ~record_dir elf)
+         let elf = Elf.create executable in
+         decode_to_trace ?elf ~record_dir decode_opts)
   ;;
 
   let commands =


### PR DESCRIPTION
magic-trace internals already supported running without decodeable
symbol and string tables, it was just the frontend that was disallowing
them. Remove that restriction.

This avoids an uninterpretable error at startup:

    (monitor.ml.Error "Option.value_exn None"
    ("Raised at Base__Error.raise in file \"error.ml\" (inlined), line 9, characters 14-30"
      "Called from Base__Option.value_exn in file \"option.ml\", line 105, characters 4-21"
      "Called from Magic_trace_lib__Trace.Make_commands.attach_command.(fun) in file \"trace.ml\", line 435, characters 21-67"
      "Called from Base__Result.try_with in file \"result.ml\", line 244, characters 9-15"
      "Caught by monitor Monitor.protect"))

...and replaces it with a log line of the form:

    [Unable to find string or symbol table, will be unable to trigger on specific symbol. Was the binary built without debug info?]

Refs #2.