### PR TITLE
Bump to dune 2.0 and set up ocamlformat

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,3 +1,6 @@
-(executables (names magic_trace_bin) (public_names magic-trace)
+(executables
+ (names magic_trace_bin)
+ (public_names magic-trace)
  (libraries core magic_trace_lib core_unix.command_unix)
- (preprocess (pps ppx_jane)))
+ (preprocess
+  (pps ppx_jane)))

--- a/core/dune
+++ b/core/dune
@@ -1,3 +1,6 @@
-(library (name magic_trace_core) (public_name magic-trace.magic_trace_core)
+(library
+ (name magic_trace_core)
+ (public_name magic-trace.magic_trace_core)
  (libraries core async core_unix.filename_unix owee re)
- (preprocess (pps ppx_jane)))
+ (preprocess
+  (pps ppx_jane)))

--- a/direct_backend/cinaps/dune
+++ b/direct_backend/cinaps/dune
@@ -1,2 +1,5 @@
-(library (name magic_trace_lib_cinaps_helpers) (libraries core)
- (preprocess (pps ppx_jane)))
+(library
+ (name magic_trace_lib_cinaps_helpers)
+ (libraries core)
+ (preprocess
+  (pps ppx_jane)))

--- a/direct_backend/decoding.ml
+++ b/direct_backend/decoding.ml
@@ -117,10 +117,10 @@ let handle_add_section (state : state) (add : Stub.Add_section.t) =
     | Some elf -> Some elf
     | None ->
       (match Elf.create add.filename with
-       | None -> None
-       | Some elf ->
-         Hashtbl.add_exn state.elfs_by_filename ~key:add.filename ~data:elf;
-         Some elf)
+      | None -> None
+      | Some elf ->
+        Hashtbl.add_exn state.elfs_by_filename ~key:add.filename ~data:elf;
+        Some elf)
   in
   match elf with
   | None -> ()
@@ -129,7 +129,7 @@ let handle_add_section (state : state) (add : Stub.Add_section.t) =
       { elf; file_offset = add.offset; loaded_offset = add.vaddr }
     in
     state.fallback_resolvers
-    <- (add.vaddr, add.size, resolver) :: state.fallback_resolvers;
+      <- (add.vaddr, add.size, resolver) :: state.fallback_resolvers;
     Hashtbl.add_exn state.resolver_by_isid ~key:add.isid ~data:resolver
 ;;
 
@@ -141,7 +141,7 @@ let convert_trace_event state (event : Stub.Event.t) =
       | None ->
         (* Tracing start/stop events don't have an isid so we need a fallback *)
         List.find state.fallback_resolvers ~f:(fun (vaddr, size, _) ->
-          event.addr > vaddr && event.addr < vaddr + size)
+            event.addr > vaddr && event.addr < vaddr + size)
         |> Option.map ~f:(fun (_, _, r) -> r)
     in
     match resolver with

--- a/direct_backend/dune
+++ b/direct_backend/dune
@@ -1,3 +1,5 @@
-(rule (targets explicit_dependencies.ml explicit_dependencies.mli)
+(rule
+ (targets explicit_dependencies.ml explicit_dependencies.mli)
  (deps %{workspace_root}/bin/gen-explicit-dependencies.sh)
- (action (bash "%{deps} libipt_a")))
+ (action
+  (bash "%{deps} libipt_a")))

--- a/direct_backend/manual_perf.ml
+++ b/direct_backend/manual_perf.ml
@@ -104,13 +104,13 @@ module Tracing_state = struct
   type t = Stub.c_tracing_state
 
   let attach
-        ?(data_size = 0x400000)
-        ?(aux_size = 0x400000)
-        ?filter
-        ~pt_file
-        ~sideband_file
-        ~setup_file
-        pid
+      ?(data_size = 0x400000)
+      ?(aux_size = 0x400000)
+      ?filter
+      ~pt_file
+      ~sideband_file
+      ~setup_file
+      pid
     =
     let state = Stub.create_empty_state () in
     let trace_meta : Stub.Trace_meta.t =
@@ -130,9 +130,9 @@ module Tracing_state = struct
       setup_file
       ~data:
         ([%sexp
-          ({ initial_maps = read_current_maps pid; trace_meta; pid = Pid.to_int pid }
-           : Setup_info.t)]
-         |> Sexp.to_string);
+           ({ initial_maps = read_current_maps pid; trace_meta; pid = Pid.to_int pid }
+             : Setup_info.t)]
+        |> Sexp.to_string);
     state
   ;;
 

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.10)
+(lang dune 2.0)

--- a/lib/src/dune
+++ b/lib/src/dune
@@ -1,3 +1,9 @@
-(library (name magic_trace) (public_name magic-trace.magic_trace)
- (c_names stop_stubs) (libraries core core_unix.time_stamp_counter)
- (preprocess (pps ppx_jane)))
+(library
+ (name magic_trace)
+ (public_name magic-trace.magic_trace)
+ (foreign_stubs
+  (language c)
+  (names stop_stubs))
+ (libraries core core_unix.time_stamp_counter)
+ (preprocess
+  (pps ppx_jane)))

--- a/lib/test/dune
+++ b/lib/test/dune
@@ -1,3 +1,5 @@
-(library (name magic_trace_test)
+(library
+ (name magic_trace_test)
  (libraries core expect_test_helpers_core magic_trace)
- (preprocess (pps ppx_jane)))
+ (preprocess
+  (pps ppx_jane)))

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,11 @@
-(library (name magic_trace_lib) (public_name magic-trace.magic_trace_lib)
- (c_names breakpoint_stubs)
+(library
+ (name magic_trace_lib)
+ (public_name magic-trace.magic_trace_lib)
+ (foreign_stubs
+  (language c)
+  (names breakpoint_stubs))
  (libraries core async core_unix.filename_unix fzf re shell
-  core_unix.sys_unix core_unix.signal_unix tracing ocaml-probes.probes_lib
-  magic_trace magic_trace_core)
- (preprocess (pps ppx_jane)))
+   core_unix.sys_unix core_unix.signal_unix tracing ocaml-probes.probes_lib
+   magic_trace magic_trace_core)
+ (preprocess
+  (pps ppx_jane)))

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -111,31 +111,31 @@ module Perf_line = struct
       line
       " %d/%d %d.%d: %s@=> %x %s"
       (fun pid tid time_hi time_lo kind addr rest ->
-         let symbol, offset =
-           try Scanf.sscanf rest "%s@+0x%x" (fun symbol offset -> symbol, offset) with
-           | Scanf.Scan_failure _ | End_of_file -> "[unknown]", 0
-         in
-         { Backend_intf.Event.thread = { pid = Pid.of_int pid; tid }
-         ; time = time_lo + (time_hi * 1_000_000_000) |> Time_ns.Span.of_int_ns
-         ; kind =
-             (match String.strip kind with
-              | "call" -> Call
-              | "return" -> Return
-              | "tr strt" -> Start
-              | "tr end" -> End None
-              | "tr end  call" -> End Call
-              | "tr end  return" -> End Return
-              | "tr end  syscall" -> End Syscall
-              | "jmp" -> Jump
-              | "jcc" -> Jump
-              | other ->
-                (* Hasn't occured in testing large traces, but there's not great documentation
+        let symbol, offset =
+          try Scanf.sscanf rest "%s@+0x%x" (fun symbol offset -> symbol, offset) with
+          | Scanf.Scan_failure _ | End_of_file -> "[unknown]", 0
+        in
+        { Backend_intf.Event.thread = { pid = Pid.of_int pid; tid }
+        ; time = time_lo + (time_hi * 1_000_000_000) |> Time_ns.Span.of_int_ns
+        ; kind =
+            (match String.strip kind with
+            | "call" -> Call
+            | "return" -> Return
+            | "tr strt" -> Start
+            | "tr end" -> End None
+            | "tr end  call" -> End Call
+            | "tr end  return" -> End Return
+            | "tr end  syscall" -> End Syscall
+            | "jmp" -> Jump
+            | "jcc" -> Jump
+            | other ->
+              (* Hasn't occured in testing large traces, but there's not great documentation
                    on what might be output for this field so raising seems like a bad idea. *)
-                Other other)
-         ; addr
-         ; symbol
-         ; offset
-         })
+              Other other)
+        ; addr
+        ; symbol
+        ; offset
+        })
   ;;
 end
 

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -21,11 +21,11 @@ let check_for_processor_trace_support () =
 let hits_file record_dir = record_dir ^/ "hits.sexp"
 
 let write_trace_from_events
-      ~verbose
-      ?debug_info
-      trace
-      hits
-      (events : Backend_intf.Event.t Pipe.Reader.t)
+    ~verbose
+    ?debug_info
+    trace
+    hits
+    (events : Backend_intf.Event.t Pipe.Reader.t)
   =
   (* Normalize to earliest event = 0 to avoid Perfetto rounding issues *)
   let%bind.Deferred earliest_time =
@@ -36,8 +36,8 @@ let write_trace_from_events
   in
   let events =
     Pipe.map events ~f:(fun (event : Backend_intf.Event.t) ->
-      if verbose then Core.print_s (Backend_intf.Event.sexp_of_t event);
-      { event with time = event.time })
+        if verbose then Core.print_s (Backend_intf.Event.sexp_of_t event);
+        { event with time = event.time })
   in
   let writer = Trace_writer.create ~debug_info ~earliest_time ~hits trace in
   let process_event ev = Trace_writer.write_event writer ev in
@@ -154,16 +154,16 @@ module Make_commands (Backend : Backend_intf.S) = struct
         let now = Time_ns.now () in
         let open Time_ns_unix.Option.Optional_syntax in
         (match%optional !last_hit with
-         | Some t ->
-           let interval = Time_ns.diff now t in
-           max_since_last_report := Time_ns.Span.max !max_since_last_report interval;
-           if Time_ns.Span.( > ) interval span_thresh
-           then take_snapshot_on_hit hit
-           else if Time_ns.( > ) now (Time_ns.add !last_report report_interval)
-           then (
-             print_report ();
-             last_report := now)
-         | _ -> ());
+        | Some t ->
+          let interval = Time_ns.diff now t in
+          max_since_last_report := Time_ns.Span.max !max_since_last_report interval;
+          if Time_ns.Span.( > ) interval span_thresh
+          then take_snapshot_on_hit hit
+          else if Time_ns.( > ) now (Time_ns.add !last_report report_interval)
+          then (
+            print_report ();
+            last_report := now)
+        | _ -> ());
         last_hit := Time_ns_unix.Option.some now
     in
     let maybe_take_snapshot hit =
@@ -216,8 +216,8 @@ module Make_commands (Backend : Backend_intf.S) = struct
             ()
         in
         (match res with
-         | `Interrupted -> Breakpoint.destroy bp
-         | `Bad_fd | `Closed | `Unsupported -> failwith "failed to wait on breakpoint")
+        | `Interrupted -> Breakpoint.destroy bp
+        | `Bad_fd | `Closed | `Unsupported -> failwith "failed to wait on breakpoint")
     in
     { recording; done_ivar; breakpoint_done; finalize_recording }
   ;;
@@ -245,8 +245,8 @@ module Make_commands (Backend : Backend_intf.S) = struct
     let { done_ivar; _ } = attachment in
     let stop = Ivar.read done_ivar in
     Async_unix.Signal.handle ~stop [ Signal.int ] ~f:(fun (_ : Signal.t) ->
-      Core.eprintf "[Got signal, detaching...]\n%!";
-      Ivar.fill_if_empty done_ivar ());
+        Core.eprintf "[Got signal, detaching...]\n%!";
+        Ivar.fill_if_empty done_ivar ());
     Core.eprintf "[Attached! Press Ctrl-C to stop recording]\n%!";
     let%bind () = stop in
     detach attachment
@@ -297,11 +297,11 @@ module Make_commands (Backend : Backend_intf.S) = struct
     and backend_opts = Backend.record_param in
     fun ~default_executable ~f ->
       (match duration_thresh, snap_symbol with
-       | Some _, Some _ ->
-         failwith
-           "Can't use -duration-thresh while using -symbol, the duration only works with \
-            Magic_trace.take_snapshot, try -delay-thresh instead."
-       | _ -> ());
+      | Some _, Some _ ->
+        failwith
+          "Can't use -duration-thresh while using -symbol, the duration only works with \
+           Magic_trace.take_snapshot, try -delay-thresh instead."
+      | _ -> ());
       let executable =
         match executable_override with
         | Some path -> path
@@ -324,16 +324,16 @@ module Make_commands (Backend : Backend_intf.S) = struct
           if cleanup then Shell.rm ~r:() ~f:() record_dir;
           Deferred.unit)
         (fun () ->
-           f
-             { backend_opts
-             ; use_filter
-             ; multi_snapshot
-             ; snap_symbol
-             ; record_dir
-             ; executable
-             ; snap_on_delay_over
-             ; duration_thresh
-             })
+          f
+            { backend_opts
+            ; use_filter
+            ; multi_snapshot
+            ; snap_symbol
+            ; record_dir
+            ; executable
+            ; snap_on_delay_over
+            ; duration_thresh
+            })
   ;;
 
   let decode_flags =
@@ -366,11 +366,11 @@ module Make_commands (Backend : Backend_intf.S) = struct
            | None -> failwithf "Can't find executable for %s" cmd ()
          in
          record_opt_fn ~default_executable ~f:(fun opts ->
-           let elf =
-             Elf.create opts.executable |> Option.value_exn ~message:"Invalid ELF"
-           in
-           let%bind () = run_and_record opts elf ~command in
-           decode_to_trace decode_opts ~record_dir:opts.record_dir elf))
+             let elf =
+               Elf.create opts.executable |> Option.value_exn ~message:"Invalid ELF"
+             in
+             let%bind () = run_and_record opts elf ~command in
+             decode_to_trace decode_opts ~record_dir:opts.record_dir elf))
   ;;
 
   let select_pid () =
@@ -418,9 +418,9 @@ module Make_commands (Backend : Backend_intf.S) = struct
            Core_unix.readlink [%string "/proc/%{pid#Pid}/exe"]
          in
          record_opt_fn ~default_executable ~f:(fun opts ->
-           let elf = Elf.create opts.executable |> Option.value_exn in
-           let%bind () = attach_and_record opts elf pid in
-           decode_to_trace decode_opts ~record_dir:opts.record_dir elf))
+             let elf = Elf.create opts.executable |> Option.value_exn in
+             let%bind () = attach_and_record opts elf pid in
+             decode_to_trace decode_opts ~record_dir:opts.record_dir elf))
   ;;
 
   let decode_command =

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,6 @@
-(library (name magic_trace_app_test)
+(library
+ (name magic_trace_app_test)
  (libraries async core expect_test_helpers_core expect_test_helpers_async
-  magic_trace_lib magic_trace_core with)
- (preprocess (pps ppx_jane)))
+   magic_trace_lib magic_trace_core with)
+ (preprocess
+  (pps ppx_jane)))

--- a/test/sample-targets/long-running/dune
+++ b/test/sample-targets/long-running/dune
@@ -1,4 +1,6 @@
-(executables (names long_running)
+(executables
+ (names long_running)
  (libraries core core_unix core_unix.core_thread core_unix.command_unix
-  magic_trace core_unix.time_ns_unix core_unix.time_stamp_counter)
- (preprocess (pps ppx_jane)))
+   magic_trace core_unix.time_ns_unix core_unix.time_stamp_counter)
+ (preprocess
+  (pps ppx_jane)))

--- a/test/sample-targets/long-running/long_running.ml
+++ b/test/sample-targets/long-running/long_running.ml
@@ -48,8 +48,8 @@ let[@inline never] rec main_loop t n =
     if t.do_snap
     then Magic_trace.take_snapshot_with_time_and_arg (Time_stamp_counter.now ()) n;
     (match t.limit with
-     | Some limit when limit >= t.num_snaps -> ()
-     | _ -> main_loop { t with last_snap = now; num_snaps = t.num_snaps + 1 } (n + 1))
+    | Some limit when limit >= t.num_snaps -> ()
+    | _ -> main_loop { t with last_snap = now; num_snaps = t.num_snaps + 1 } (n + 1))
   | false ->
     if t.sleeps && n % 4000 = 0 then ignore (Core_unix.nanosleep 0.001 : float);
     main_loop t (n + 1)
@@ -85,8 +85,8 @@ let command =
            Core_thread.create
              ~on_uncaught_exn:`Kill_whole_process
              (fun () ->
-                let t2 = { t with do_snap = false } in
-                main_loop t2 0)
+               let t2 = { t with do_snap = false } in
+               main_loop t2 0)
              ()
            |> Some
        in

--- a/test/sample-targets/ocaml-raise/dune
+++ b/test/sample-targets/ocaml-raise/dune
@@ -1,4 +1,6 @@
-(executables (names sample)
+(executables
+ (names sample)
  (libraries core core_unix core_unix.command_unix magic_trace
-  core_unix.time_stamp_counter)
- (preprocess (pps ppx_jane)))
+   core_unix.time_stamp_counter)
+ (preprocess
+  (pps ppx_jane)))

--- a/test/sample-targets/variable-duration/dune
+++ b/test/sample-targets/variable-duration/dune
@@ -1,3 +1,5 @@
-(executables (names variable_duration)
+(executables
+ (names variable_duration)
  (libraries core core_unix ocaml_intrinsics magic_trace)
- (preprocess (pps ppx_jane)))
+ (preprocess
+  (pps ppx_jane)))

--- a/test/test.ml
+++ b/test/test.ml
@@ -519,13 +519,13 @@ let%expect_test "get debug information from ELF" =
   let debug_table =
     Magic_trace_core.Elf.addr_table (Option.value_exn elf)
     |> Hashtbl.filter ~f:(fun info ->
-      match info.filename with
-      | Some "sample.ml" -> true
-      | _ -> false)
+           match info.filename with
+           | Some "sample.ml" -> true
+           | _ -> false)
   in
   let raise_after_col =
     Hashtbl.filter_map debug_table ~f:(fun info ->
-      if info.line = 5 then Some info.col else None)
+        if info.line = 5 then Some info.col else None)
     |> Hashtbl.data
     |> List.hd_exn
   in


### PR DESCRIPTION
Ran `dune build @fmt --auto-promote` to accept changes. There are some
because this code originally was passed through `ocamlformat` and
`ocp-indent`, and we're not going to replicate the precise `ocp-indent`
here.