### PR TITLE
Fix tests depending on internal library

### DIFF
--- a/direct_backend/dune
+++ b/direct_backend/dune
@@ -1,5 +1,0 @@
-(rule
- (targets explicit_dependencies.ml explicit_dependencies.mli)
- (deps %{workspace_root}/bin/gen-explicit-dependencies.sh)
- (action
-  (bash "%{deps} libipt_a")))

--- a/magic-trace.opam
+++ b/magic-trace.opam
@@ -14,6 +14,7 @@ depends: [
   "async"
   "core"
   "core_unix"
+  "expect_test_helpers_async"
   "fzf"
   "ocaml-probes"
   "ppx_jane"

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,6 @@
 (library
  (name magic_trace_app_test)
  (libraries async core expect_test_helpers_core expect_test_helpers_async
-   magic_trace_lib magic_trace_core with)
+   magic_trace_lib magic_trace_core)
  (preprocess
   (pps ppx_jane)))

--- a/test/test.ml
+++ b/test/test.ml
@@ -84,6 +84,16 @@ end = struct
   let () = ignore (events () : Event.t list)
 end
 
+module With = struct
+  let bind with_ ~f = with_ f
+
+  module Let_syntax = struct
+    module Let_syntax = struct
+      let bind = bind
+    end
+  end
+end
+
 let dump_using_file events =
   let buf = Iobuf.create ~len:500_000 in
   let destination = Tracing_zero.Destinations.iobuf_destination buf in


### PR DESCRIPTION
`with` is a trivial internal library that's not public-release'd. Inline
its contents so that tests may build.

Depends on https://github.com/janestreet/magic-trace/pull/11.