### PR TITLE
Add a dune file to the root of the repo

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,3 @@
+(env
+ (release
+  (ocamlopt_flags (:standard -O3))))


### PR DESCRIPTION
Add a dune file to the root of the repo so people can run:

$ dune build --release

for an optimized build

or

$ dune build --profile dev

for a... build with an extra warning enabled? I'm just following the dune tutorial, man. This isn't entirely well thought out.