### PR TITLE
Make the output file mandatory.

### DIFF
--- a/src/trace.ml
+++ b/src/trace.ml
@@ -58,7 +58,6 @@ module Make_commands (Backend : Backend_intf.S) = struct
     Core.eprintf "[Decoding, this may take 30s or so...]\n%!";
     Tracing_tool_output.write_and_view
       output_config
-      ~default_name:"magic_trace"
       ~f:(fun w ->
         let open Deferred.Or_error.Let_syntax in
         let trace_writer = Tracing.Trace.Expert.create ~base_time:None w in

--- a/src/tracing_tool_output.mli
+++ b/src/tracing_tool_output.mli
@@ -14,7 +14,6 @@ val param : t Command.Param.t
 val write_and_view
   :  ?num_temp_strs:int
   -> t
-  -> default_name:string
   -> f:(Tracing_zero.Writer.t -> 'a Deferred.Or_error.t)
   -> 'a Deferred.Or_error.t
 


### PR DESCRIPTION
The temporary file path was kind of buggy (e.g. it would output temporary files with XXXXXX in the name). In lieu of actually thinking about that code path and fixing bugs, this feature makes the output
flag mandatory rather than optional.