### PR TITLE
Support kernel-mode tracing

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -16,6 +16,7 @@ module type S = sig
 
     val attach_and_record
       :  Record_opts.t
+      -> trace_mode:Trace_mode.t
       -> record_dir:string
       -> Pid.t
       -> t Deferred.Or_error.t

--- a/core/event.ml
+++ b/core/event.ml
@@ -5,8 +5,10 @@ module End_kind = struct
     | Call
     | Return
     | Syscall
+    | Sysret
+    | Iret
     | None
-  [@@deriving sexp]
+  [@@deriving sexp, compare, equal]
 end
 
 module Kind = struct
@@ -14,10 +16,14 @@ module Kind = struct
     | Call
     | Return
     | Start
+    | Syscall
+    | Sysret
+    | Hardware_interrupt
+    | Iret
     | Decode_error
     | End of End_kind.t
     | Jump
-  [@@deriving sexp]
+  [@@deriving sexp, compare, equal]
 end
 
 module Thread = struct

--- a/core/event.mli
+++ b/core/event.mli
@@ -5,8 +5,10 @@ module End_kind : sig
     | Call
     | Return
     | Syscall
+    | Sysret
+    | Iret
     | None
-  [@@deriving sexp]
+  [@@deriving sexp, compare, equal]
 end
 
 module Kind : sig
@@ -14,10 +16,14 @@ module Kind : sig
     | Call
     | Return
     | Start
+    | Syscall
+    | Sysret
+    | Hardware_interrupt
+    | Iret
     | Decode_error
     | End of End_kind.t
     | Jump
-  [@@deriving sexp]
+  [@@deriving sexp, compare, equal]
 end
 
 module Thread : sig

--- a/core/trace_mode.ml
+++ b/core/trace_mode.ml
@@ -1,0 +1,21 @@
+open! Core
+
+type t =
+  | Userspace
+  | Kernel
+  | Userspace_and_kernel
+[@@deriving sexp_of, compare, equal]
+
+let commands_and_docs =
+  [ Userspace, "trace-userspace", "trace userspace only"
+  ; Userspace_and_kernel, "trace-include-kernel", "trace userspace and kernel"
+  ; Kernel, "trace-kernel-only", "trace kernel only"
+  ]
+;;
+
+let param =
+  Command.Param.choose_one
+    ~if_nothing_chosen:(Default_to Userspace)
+    (List.map commands_and_docs ~f:(fun (variant, flag, doc) ->
+         Command.Param.flag flag (Command.Param.no_arg_some variant) ~doc))
+;;

--- a/core/trace_mode.mli
+++ b/core/trace_mode.mli
@@ -1,0 +1,9 @@
+open! Core
+
+type t =
+  | Userspace
+  | Kernel
+  | Userspace_and_kernel
+[@@deriving sexp_of, compare, equal]
+
+val param : t Command.Param.t

--- a/src/import.ml
+++ b/src/import.ml
@@ -2,3 +2,4 @@ module Backend_intf = Magic_trace_core.Backend_intf
 module Event = Magic_trace_core.Event
 module Elf = Magic_trace_core.Elf
 module Errno = Magic_trace_core.Errno
+module Trace_mode = Magic_trace_core.Trace_mode

--- a/src/perf_capabilities.ml
+++ b/src/perf_capabilities.ml
@@ -3,12 +3,20 @@ open! Async
 
 let bit n = Int63.of_int (1 lsl n)
 let configurable_psb_period = bit 0
+let kernel_tracing = bit 1
+let kcore = bit 2
 
 include Flags.Make (struct
   let allow_intersecting = false
   let should_print_error = true
   let remove_zero_flags = false
-  let known = [ configurable_psb_period, "configurable_psb_period" ]
+
+  let known =
+    [ configurable_psb_period, "configurable_psb_period"
+    ; kernel_tracing, "kernel_tracing"
+    ; kcore, "kcore"
+    ]
+  ;;
 end)
 
 module Version = struct
@@ -18,7 +26,7 @@ module Version = struct
     }
   [@@deriving sexp_of, compare]
 
-  let _create ~major ~minor = { major; minor }
+  let create ~major ~minor = { major; minor }
 
   let of_perf_version_string_exn version_string =
     try
@@ -38,15 +46,36 @@ let supports_configurable_psb_period () =
   String.( = ) cyc_cap "1\n"
 ;;
 
+let supports_tracing_kernel () =
+  (* Only allow tracing the kernel if we are root. `perf` will start even without this,
+     but the generated traces will be broken, so disallow it here.
+
+     This check is technically stricter than it has to be. We could query the capability
+     bits of the perf binary here instead, as per
+     <https://perf.wiki.kernel.org/index.php/Perf_tools_support_for_Intel%C2%AE_Processor_Trace#Adding_capabilities_to_perf> *)
+  Int.(Core_unix.geteuid () = 0)
+;;
+
+let supports_kcore version =
+  (* Added in kernel commit eeb399b, which made it in 5.5. *)
+  Int.(Version.compare version (Version.create ~major:5 ~minor:5) >= 0)
+;;
+
 let detect_exn () =
   let%bind perf_version_proc = Process.create_exn ~prog:"perf" ~args:[ "--version" ] () in
   let%map version_string = Reader.contents (Process.stdout perf_version_proc) in
-  let _version = Version.of_perf_version_string_exn version_string in
+  let version = Version.of_perf_version_string_exn version_string in
   let capabilities = empty in
   let capabilities =
     if supports_configurable_psb_period ()
     then capabilities + configurable_psb_period
     else capabilities
+  in
+  let capabilities =
+    if supports_tracing_kernel () then capabilities + kernel_tracing else capabilities
+  in
+  let capabilities =
+    if supports_kcore version then capabilities + kcore else capabilities
   in
   capabilities
 ;;

--- a/src/perf_capabilities.mli
+++ b/src/perf_capabilities.mli
@@ -6,4 +6,6 @@ type t = private Int63.t [@@deriving sexp_of]
 include Flags.S with type t := t
 
 val configurable_psb_period : t
+val kernel_tracing : t
+val kcore : t
 val detect_exn : unit -> t Deferred.t

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -142,8 +142,8 @@ module Perf_line = struct
   let report_fields = "pid,tid,time,flags,ip,addr,sym,symoff"
 
   let line_re =
-    Re.Posix.re
-      {|^ *([0-9]+)/([0-9]+) +([0-9]+).([0-9]+): +(call|return|tr strt|syscall|sysret|hw int|iret|tr end|tr strt tr end|tr end  call|tr end  return|tr end  syscall|tr end  sysret|tr end  iret|jmp|jcc) +([0-9a-f]+) (.*) => +([0-9a-f]+) (.*)$|}
+    Re.Perl.re
+      {|^ *([0-9]+)/([0-9]+) +([0-9]+).([0-9]+): +(call|return|tr strt|syscall|sysret|hw int|iret|tr end|tr strt tr end|tr end  (?:call|return|syscall|sysret|iret)|jmp|jcc) +([0-9a-f]+) (.*) => +([0-9a-f]+) (.*)$|}
     |> Re.compile
   ;;
 

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -1,4 +1,4 @@
-(** Runs a program under Intel ProcessorTrace in Snapshot mode *)
+(** Runs a program under Intel Processor Trace in Snapshot mode *)
 open! Core
 
 open! Async
@@ -44,6 +44,7 @@ let check_for_processor_trace_support () =
 
 let write_trace_from_events
     ~verbose
+    ~trace_mode
     ?debug_info
     trace
     hits
@@ -61,7 +62,7 @@ let write_trace_from_events
         if verbose then Core.print_s (Event.sexp_of_t event);
         { event with time = event.time })
   in
-  let writer = Trace_writer.create ~debug_info ~earliest_time ~hits trace in
+  let writer = Trace_writer.create ~trace_mode ~debug_info ~earliest_time ~hits trace in
   let process_event ev = Trace_writer.write_event writer ev in
   let%map () = Pipe.iter_without_pushback events ~f:process_event in
   Trace_writer.flush_all writer
@@ -82,7 +83,11 @@ module Make_commands (Backend : Backend_intf.S) = struct
     let filename ~record_dir = record_dir ^/ "hits.sexp"
   end
 
-  let decode_to_trace ~elf ~record_dir { Decode_opts.output_config; decode_opts; verbose }
+  let decode_to_trace
+      ~elf
+      ~trace_mode
+      ~record_dir
+      { Decode_opts.output_config; decode_opts; verbose }
     =
     Core.eprintf "[Decoding, this may take 30s or so...]\n%!";
     Tracing_tool_output.write_and_view output_config ~f:(fun w ->
@@ -96,7 +101,13 @@ module Make_commands (Backend : Backend_intf.S) = struct
         let debug_info = Option.map elf ~f:Elf.addr_table in
         let%bind event_pipe = Backend.decode_events decode_opts ~record_dir in
         let%bind () =
-          write_trace_from_events ?debug_info ~verbose trace_writer hits event_pipe
+          write_trace_from_events
+            ?debug_info
+            ~trace_mode
+            ~verbose
+            trace_writer
+            hits
+            event_pipe
           |> Deferred.ok
         in
         Tracing.Trace.close trace_writer;
@@ -110,6 +121,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
       ; when_to_snapshot : When_to_snapshot.t
       ; record_dir : string
       ; executable : string
+      ; trace_mode : Trace_mode.t
       }
   end
 
@@ -158,6 +170,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
     let%map.Deferred.Or_error recording =
       Backend.Recording.attach_and_record
         opts.backend_opts
+        ~trace_mode:opts.trace_mode
         ~record_dir:opts.record_dir
         pid
     in
@@ -299,6 +312,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
              | Some symbol -> Application_calls_a_function (User_selected symbol))
     and multi_snapshot =
       flag "-multi-snapshot" no_arg ~doc:"allow taking multiple snapshots if possible"
+    and trace_mode = Trace_mode.param
     and backend_opts = Backend.Record_opts.param in
     fun ~default_executable ~f ->
       let executable =
@@ -324,6 +338,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
             ; when_to_snapshot
             ; record_dir
             ; executable
+            ; trace_mode
             })
   ;;
 
@@ -357,10 +372,13 @@ module Make_commands (Backend : Backend_intf.S) = struct
            | None -> failwithf "Can't find executable for %s" cmd ()
          in
          record_opt_fn ~default_executable ~f:(fun opts ->
-             let { Record_opts.executable; when_to_snapshot; _ } = opts in
-             let%bind elf = create_elf ~executable ~when_to_snapshot in
+             let elf = Elf.create opts.executable in
              let%bind () = run_and_record ~elf ~command opts in
-             decode_to_trace ~elf ~record_dir:opts.record_dir decode_opts))
+             decode_to_trace
+               ~elf
+               ~trace_mode:opts.trace_mode
+               ~record_dir:opts.record_dir
+               decode_opts))
   ;;
 
   let select_pid () =
@@ -426,7 +444,11 @@ module Make_commands (Backend : Backend_intf.S) = struct
              let { Record_opts.executable; when_to_snapshot; _ } = opts in
              let%bind elf = create_elf ~executable ~when_to_snapshot in
              let%bind () = attach_and_record ?elf opts pid in
-             decode_to_trace ~elf ~record_dir:opts.record_dir decode_opts))
+             decode_to_trace
+               ~elf
+               ~trace_mode:opts.trace_mode
+               ~record_dir:opts.record_dir
+               decode_opts))
   ;;
 
   let decode_command =
@@ -434,6 +456,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
       ~summary:
         "Decode processor trace data and convert the results to a viewable Fuchsia trace."
       (let%map_open.Command record_dir = record_dir_flag required
+       and trace_mode = Trace_mode.param
        and decode_opts = decode_flags
        and executable =
          flag
@@ -445,7 +468,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
          (* Doesn't use create_elf because there's no need to check that the binary has symbols if
             we're trying to snapshot it. *)
          let elf = Elf.create executable in
-         decode_to_trace ~elf ~record_dir decode_opts)
+         decode_to_trace ~elf ~trace_mode ~record_dir decode_opts)
   ;;
 
   let commands =

--- a/src/trace.mli
+++ b/src/trace.mli
@@ -6,7 +6,8 @@ val command : Command.t
 
 module For_testing : sig
   val write_trace_from_events
-    :  ?debug_info:Elf.Addr_table.t
+    :  trace_mode:Trace_mode.t
+    -> ?debug_info:Elf.Addr_table.t
     -> Tracing.Trace.t
     -> (string * Breakpoint.Hit.t) list
     -> Event.t Pipe.Reader.t

--- a/src/trace_writer.mli
+++ b/src/trace_writer.mli
@@ -4,7 +4,8 @@ open! Import
 type t
 
 val create
-  :  debug_info:Elf.Addr_table.t option
+  :  trace_mode:Trace_mode.t
+  -> debug_info:Elf.Addr_table.t option
   -> earliest_time:Time_ns.Span.t
   -> hits:(string * Breakpoint.Hit.t) list
   -> Tracing.Trace.t

--- a/test/test.ml
+++ b/test/test.ml
@@ -113,7 +113,7 @@ let dump_using_file events =
   let destination = Tracing_zero.Destinations.iobuf_destination buf in
   let writer = Tracing_zero.Writer.Expert.create ~destination () in
   let trace = Tracing.Trace.Expert.create ~base_time:None writer in
-  let%bind () = write_trace_from_events trace [] events in
+  let%bind () = write_trace_from_events ~trace_mode:Userspace trace [] events in
   Tracing.Trace.close trace;
   let parser = Tracing.Parser.create (Iobuf.read_only buf) in
   while%bind_open.Result Ok true do


### PR DESCRIPTION
Some examples below.

Tall ticks are timer interrupts. Short ones are the application under test occasionally performing a read syscall. Timer interrupts occur every 1ms.
![p (1)](https://user-images.githubusercontent.com/1403503/158909804-da19e460-d550-4a83-8e62-1db4a0343392.png)

Zoomed in on a timer interrupt, they take ~600ns.
![p](https://user-images.githubusercontent.com/1403503/158909803-8795d60d-750c-4f1e-b81f-ea38b1dae7c3.png)

Interrupts while running on a core servicing ethernet device interrupts while running `iperf`. Interrupt moderation is visible, with polling ticks ~130us apart. 
![p (2)](https://user-images.githubusercontent.com/1403503/158909806-494e88ed-55ac-4195-b13d-f1e4de90c66d.png)
