### PR TITLE
Move .github/workflows/dco.yml to .github/dco.yml

### DIFF
--- a/.github/workflows/dco.ml
+++ b/.github/workflows/dco.ml
@@ -1,2 +1,0 @@
-require:
-  members: false


### PR DESCRIPTION
GitHub should pick it up now.

Signed-off-by: Tudor Brindus <tbrindus@janestreet.com>