### PR TITLE
Raise on unknown perf event kind

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -19,7 +19,6 @@ module Event = struct
     | Decode_error
     | End of end_kind
     | Jump
-    | Other of string
     | Unknown
   [@@deriving sexp]
 

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -128,10 +128,12 @@ module Perf_line = struct
             | "tr end  syscall" -> End Syscall
             | "jmp" -> Jump
             | "jcc" -> Jump
-            | other ->
-              (* Hasn't occured in testing large traces, but there's not great documentation
-                   on what might be output for this field so raising seems like a bad idea. *)
-              Other other)
+            | kind ->
+              raise_s [%message
+                 "BUG: unrecognized perf event. Please report this to \
+                  https://github.com/janestreet/magic-trace/issues/"
+                   (kind : string)
+                   ~unrecognized_perf_output:(line : string)])
         ; addr
         ; symbol
         ; offset

--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -282,7 +282,7 @@ let write_event (t : t) ({ thread; time; symbol; kind; addr; offset } : Event.t)
       (* If we have no callstack left, then we just returned out of something we didn't
          see the call for. Since we're in snapshot mode, this happens with functions
          called before the perf events started, so add in a call that begins at the
-         start of the trace for that pid. 
+         start of the trace for that pid.
 
          These shouldn't be buffered for spreading since we want them exactly at the reset
          time. *)
@@ -342,5 +342,5 @@ let write_event (t : t) ({ thread; time; symbol; kind; addr; offset } : Event.t)
     flush_all t;
     thread_info.reset_time <- time
   | Jump -> check_current_symbol ()
-  | Other _ | Unknown -> ()
+  | Unknown -> ()
 ;;


### PR DESCRIPTION
This PR makes magic-trace raise when it sees an unrecognized perf event kind instead of silently ignoring it.

Unrecognized perf events are bugs. Silently ignoring them was a fine idea during initial devleopment of magic-trace, but has quickly fallen off as an optimal strategy as we try to fix the long tail of issues in
different environments.