### PR TITLE
Support PIDs and TIDs of 0

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -25,8 +25,8 @@ module Event = struct
 
   module Thread = struct
     type t =
-      { pid : Pid.t
-      ; tid : int
+      { pid : Pid.t option
+      ; tid : int option
       }
     [@@deriving sexp, compare, hash]
   end

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -115,7 +115,11 @@ module Perf_line = struct
           try Scanf.sscanf rest "%s@+0x%x" (fun symbol offset -> symbol, offset) with
           | Scanf.Scan_failure _ | End_of_file -> "[unknown]", 0
         in
-        { Backend_intf.Event.thread = { pid = Pid.of_int pid; tid }
+        { Backend_intf.Event.
+          thread =
+            { pid = if pid = 0 then None else Some (Pid.of_int pid)
+            ; tid = if tid = 0 then None else Some tid
+            }
         ; time = time_lo + (time_hi * 1_000_000_000) |> Time_ns.Span.of_int_ns
         ; kind =
             (match String.strip kind with

--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -229,6 +229,16 @@ let add_event t thread time ev =
   thread.pending_events <- ev :: thread.pending_events
 ;;
 
+let opt_pid_to_string opt_pid =
+  match opt_pid with
+  | None -> "?"
+  | Some pid -> Pid.to_string pid
+
+let opt_int_to_string opt_int =
+  match opt_int with
+  | None -> "?"
+  | Some int -> Int.to_string int
+
 (** Write perf_events into a file as a Fuschia trace (stack events). Events should be
     collected with --itrace=b or cre, and -F pid,tid,time,flags,addr,sym,symoff as per the
     constants defined above. *)
@@ -239,7 +249,7 @@ let write_event (t : t) ({ thread; time; symbol; kind; addr; offset } : Event.t)
         let trace_pid =
           Tracing.Trace.allocate_pid
             t.trace
-            ~name:[%string "%{thread.pid#Pid}/%{thread.tid#Int}"]
+            ~name:[%string "%{opt_pid_to_string thread.pid}/%{opt_int_to_string thread.tid}"]
         in
         let thread = Tracing.Trace.allocate_thread t.trace ~pid:trace_pid ~name:"main" in
         { thread
@@ -282,7 +292,7 @@ let write_event (t : t) ({ thread; time; symbol; kind; addr; offset } : Event.t)
       (* If we have no callstack left, then we just returned out of something we didn't
          see the call for. Since we're in snapshot mode, this happens with functions
          called before the perf events started, so add in a call that begins at the
-         start of the trace for that pid. 
+         start of the trace for that pid.
 
          These shouldn't be buffered for spreading since we want them exactly at the reset
          time. *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -12,7 +12,7 @@ module Trace_helpers : sig
   val jmp : unit -> unit
 end = struct
   let start_time = Time_ns.Span.of_int_ns 12345
-  let thread : Event.Thread.t = { pid = Pid.of_int 1234; tid = 456 }
+  let thread : Event.Thread.t = { pid = Some (Pid.of_int 1234); tid = Some 456 }
   let stack = Stack.create ()
   let events = Queue.create ()
   let cur_time = ref start_time


### PR DESCRIPTION
Perf uses PID=0 or TID=0 to attach no PID or TID to an event. When it does that, make magic-trace treat them as optional. When it actually goes to write a trace, it now writes a PID/TID of '?'.

Previous behavior was to crash on Pid.of_int if the int was 0.