### PR TITLE
Remove the `Unknown` variant for events

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -19,7 +19,6 @@ module Event = struct
     | Decode_error
     | End of end_kind
     | Jump
-    | Unknown
   [@@deriving sexp]
 
   module Thread = struct

--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -352,5 +352,4 @@ let write_event (t : t) ({ thread; time; symbol; kind; addr; offset } : Event.t)
     flush_all t;
     thread_info.reset_time <- time
   | Jump -> check_current_symbol ()
-  | Unknown -> ()
 ;;


### PR DESCRIPTION
All events are known. All events must be known. If we don't know an event, it's a bug.