### PR TITLE
Add partial support for kernel addresses

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -33,7 +33,7 @@ module Event = struct
   type t =
     { thread : Thread.t
     ; time : Time_ns.Span.t
-    ; addr : int
+    ; addr : int64
     ; kind : kind
     ; symbol : string
     ; offset : int

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -109,7 +109,7 @@ module Perf_line = struct
   let to_event line =
     Scanf.sscanf
       line
-      " %d/%d %d.%d: %s@=> %x %s@$"
+      " %d/%d %d.%d: %s@=> %Lx %s@$"
       (fun pid tid time_hi time_lo kind addr rest ->
         let symbol, offset =
           try Scanf.sscanf rest "%s@+0x%x" (fun symbol offset -> symbol, offset) with

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -56,9 +56,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
 
   let decode_to_trace ?elf ~record_dir { output_config; decode_opts; verbose } =
     Core.eprintf "[Decoding, this may take 30s or so...]\n%!";
-    Tracing_tool_output.write_and_view
-      output_config
-      ~f:(fun w ->
+    Tracing_tool_output.write_and_view output_config ~f:(fun w ->
         let open Deferred.Or_error.Let_syntax in
         let trace_writer = Tracing.Trace.Expert.create ~base_time:None w in
         let hits =
@@ -109,7 +107,9 @@ module Make_commands (Backend : Backend_intf.S) = struct
           | 1, Some (_, s) -> Deferred.Or_error.return (Some s)
           | _ -> Fzf.pick_one (Fzf.Pick_from.Map snap_syms)
         in
-        let snap_loc = Option.map snap_sym ~f:(fun sym -> Elf.symbol_stop_info elf pid sym) in
+        let snap_loc =
+          Option.map snap_sym ~f:(fun sym -> Elf.symbol_stop_info elf pid sym)
+        in
         let filter =
           match opts.use_filter, snap_loc with
           | true, Some { Elf.Stop_info.filter; _ } -> Some filter
@@ -242,7 +242,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
     let%bind attachment = attach ?elf record_opts pid in
     Probes_lib.Raw_ptrace.detach (Pid.to_int pid);
     Async_unix.Signal.handle Async_unix.Signal.terminating ~f:(fun signal ->
-      UnixLabels.kill ~pid:(Pid.to_int pid) ~signal:(Signal_unix.to_system_int signal));
+        UnixLabels.kill ~pid:(Pid.to_int pid) ~signal:(Signal_unix.to_system_int signal));
     let%bind.Deferred (_ : Core_unix.Exit_or_signal.t) = Async_unix.Unix.waitpid pid in
     detach attachment
   ;;

--- a/src/tracing_tool_output.ml
+++ b/src/tracing_tool_output.ml
@@ -116,10 +116,7 @@ type t =
 
 let param =
   let%map_open.Command store_path =
-    flag
-      "output"
-      (required string)
-      ~doc:"FILE output file name"
+    flag "output" (required string) ~doc:"FILE output file name"
   and serve = flag "serve" no_arg ~doc:"also serve the trace"
   and serve_info = Serve.param in
   { serve_info; serve; store_path }

--- a/test/test.ml
+++ b/test/test.ml
@@ -24,7 +24,7 @@ end = struct
     !cur_time
   ;;
 
-  let addr () = Random.State.int_incl !rng 0 0x7fffffffffff
+  let addr () = Random.State.int64_incl !rng 0L 0x7fffffffffffL
   let offset () = Random.State.int_incl !rng 0 0x1000
 
   let symbol () =
@@ -52,7 +52,7 @@ end = struct
 
   let add kind ns symbol =
     let time = Time_ns.Span.of_int_ns ns in
-    Queue.enqueue events { thread; time; kind; symbol; addr = 0; offset = 0 }
+    Queue.enqueue events { thread; time; kind; symbol; addr = 0L; offset = 0 }
   ;;
 
   let ret () =


### PR DESCRIPTION
Kernel addresses have the highest bit set, which means they don't fit in
an OCaml `int`. Also, parsing fails.

Switch to parsing and processing `int64`s. At the boundary to `Tracing`,
truncate to regular `int`s until `Tracing` gains support for `int64`s.

Signed-off-by: Tudor Brindus <tbrindus@janestreet.com>