### PR TITLE
Add some example programs

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,7 @@
+# Demonstrations
+
+This directory contains programs that demonstrate how to use magic trace with
+different languages.
+
+To play around with one, run it (e.g. ./demo.js) and use magic-trace to create
+a trace.

--- a/demo/demo.c
+++ b/demo/demo.c
@@ -1,0 +1,19 @@
+///usr/bin/env -S clang -gdwarf-4 "$0" -o /tmp/demo && exec /tmp/demo "$@"
+#include <unistd.h>
+#include <fcntl.h>
+
+int main(void)
+{
+    int r = open("/dev/zero", O_RDONLY);
+    int w = open("/dev/null", O_WRONLY);
+    char buf[4096] = {0};
+    for (;;)
+    {
+        ssize_t bytes_read = read(r, buf, sizeof(buf));
+        if (bytes_read < 0)
+            break;
+        if (write(w, buf, (size_t)bytes_read) < 0)
+            break;
+    }
+    return 0;
+}

--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -1,0 +1,19 @@
+///usr/bin/env -S clang++ -gdwarf-4 "$0" -o /tmp/demo && exec /tmp/demo "$@"
+#include <fstream>
+
+using namespace std;
+
+int main()
+{
+    ifstream r;
+    ofstream w;
+    r.open("/dev/zero", ios::binary);
+    w.open("/dev/null", ios::binary);
+    char buf[4096] = {0};
+    for (;;)
+    {
+        r.read(buf, sizeof(buf));
+        w.write(buf, sizeof(buf));
+    }
+    return 0;
+}

--- a/demo/demo.go
+++ b/demo/demo.go
@@ -1,0 +1,25 @@
+///usr/bin/true; exec /usr/bin/env go run -ldflags=-compressdwarf=false -gcflags "-N -l" "$0" "$@"
+package main
+
+import (
+	"os"
+)
+
+func check(e error) {
+    if e != nil {
+        panic(e)
+    }
+}
+
+func main() {
+	r, err := os.Open("/dev/zero")
+    check(err)
+	w, err := os.Create("/dev/null")
+	check(err)
+	buf := make([]byte, 4096)
+	for {
+		_, err = r.Read(buf)
+		_, err = w.Write(buf)
+		check(err)
+	}
+}

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env -S node --perf-basic-prof
+// Magic-trace requires a map of JIT-ed symbols, which node will
+// generate if you provide --perf-basic-prof.
+
+// Spams HTTP requests to an HTTP server. One connection, one request in flight at all times.
+const http = require('http');
+const PORT = 40210
+
+function req(req, resp) {
+   resp.end()
+}
+
+server = http.createServer(req);
+server.listen(PORT);
+
+const options = { host: '127.0.0.1', method: 'GET', path: '/', port: PORT }
+
+const reqloop = () => {
+   var request = http.request(options, (response) => reqloop())
+   request.end()
+};
+
+reqloop();

--- a/demo/demo.ml
+++ b/demo/demo.ml
@@ -1,0 +1,11 @@
+#!/usr/bin/env ocaml
+
+let () =
+  let r = open_in "/dev/zero" in
+  let w = open_out "/dev/null" in
+  let buf = Bytes.create 4096 in
+  while true do
+    let bytes_read = input r buf 0 (Bytes.length buf) in
+    output w buf 0 bytes_read
+  done
+;;

--- a/demo/java
+++ b/demo/java
@@ -1,0 +1,17 @@
+#!/usr/bin/env -S java --source 11
+
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class java {
+    public static void main(String[] args) throws IOException {
+        FileReader r = new FileReader("/dev/zero");
+        FileWriter w = new FileWriter("/dev/null");
+        char[] buf = new char[4096];
+        for (;;) {
+            int bytesRead = r.read(buf);
+            w.write(buf, 0, bytesRead);
+        }
+    }
+}


### PR DESCRIPTION
These programs are meant to be used with magic trace to quickly test out
whether or not it's working properly. Through varying degrees of
trickery, they can all be run via shebang.

All except the node.js example pipe bytes from /dev/zero to /dev/null.
The node.js example sends HTTP requests to itself. There's no principled
reason why it doesn't do the same thing, I just found HTTP easier deal
with in node than files.

The java demo is just called `java` instead of `demo.java` because
giving it a proper file extension breaks the shebang.

Partially addresses #44. But I don't consider it a complete solution to that
issue. These are demos, but they're not very accessible to people yet.