### PR TITLE
Prefix `perf.data` with `record_dir` in `perf script` command

### DIFF
--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -175,7 +175,7 @@ let decode_events () ~record_dir =
   let args =
     [ "script"
     ; "-i"
-    ; "perf.data"
+    ; record_dir ^/ "perf.data"
     ; "--ns"
     ; [%string "--itrace=%{Perf_line.report_itraces}"]
     ; "-F"


### PR DESCRIPTION
This is functionally equivalent, but makes `debug_perf_commands` a
little easier to copy-paste.