### PR TITLE
Add caching of ~/.opam on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - uses: actions/cache@v2
+        with:
+          path: ~/.opam
+          key: ${{ matrix.os }}-opam-${{ matrix.ocaml-version }}
+          restore-keys: |
+            ${{ matrix.os }}-opam-${{ matrix.ocaml-version }}
+
       - name: Use OCaml ${{ matrix.ocaml-version }}
         uses: ocaml/setup-ocaml@v1
         with:


### PR DESCRIPTION
This reduced the CI execution time from [>22 minutes](https://github.com/quantum5/magic-trace/actions/runs/2037760651) to [1 minute](https://github.com/quantum5/magic-trace/actions/runs/2037845679).