### PR TITLE
Upload magic-trace binary to GitHub releases when tagging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,3 +46,13 @@ jobs:
           name: magic-trace
           path: _build/install/default/bin/magic-trace
           if-no-files-found: error
+
+      - name: Upload to GitHub releases
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: _build/install/default/bin/magic-trace
+          asset_name: magic-trace
+          tag: ${{ github.ref }}
+          overwrite: true


### PR DESCRIPTION
When a release is created, this PR will make it build the `magic-trace` binary and attach it to the release automatically.

Example: https://github.com/quantum5/magic-trace/releases/tag/binary-upload-test

Refs #68.