### PR TITLE
Upload magic-trace deb package to GitHub releases when tagging

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -27,3 +27,13 @@ jobs:
           name: Packages
           path: '*.deb'
           if-no-files-found: error
+
+      - name: Upload to GitHub releases
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: '*.deb'
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true


### PR DESCRIPTION
When a release is created, this PR will make it build the `.deb` package and attach it to the release automatically.

Example: https://github.com/quantum5/magic-trace/releases/tag/v0.0.2-deb-test

Refs #68.