### PR TITLE
Some README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
   <br/>
   magic-trace
 </h1>
-  <p align="center">
-    <a href="https://github.com/janestreet/magic-trace/actions?query=workflow%3Abuild" alt="Linux Build Status">
-      <img src="https://img.shields.io/github/workflow/status/janestreet/magic-trace/build?logo=github&style=flat-square"/>
+<p align="center">
+  <a href="https://github.com/janestreet/magic-trace/actions?query=workflow%3Abuild" alt="Linux Build Status">
+    <img src="https://img.shields.io/github/workflow/status/janestreet/magic-trace/build?logo=github&style=flat-square"/>
   </a>
   <a href="https://github.com/janestreet/magic-trace/releases/latest">
     <img src="https://img.shields.io/github/v/tag/janestreet/magic-trace?label=version&style=flat-square"/>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
   <a href="https://github.com/janestreet/magic-trace/releases/latest">
     <img src="https://img.shields.io/github/v/tag/janestreet/magic-trace?label=version&style=flat-square"/>
   </a>
-  <img src="https://img.shields.io/github/license/janestreet/magic-trace?style=flat-square"/>
+  <a href="LICENSE.md">
+    <img src="https://img.shields.io/github/license/janestreet/magic-trace?style=flat-square"/>
+  </a>
 </p>
 
 Magic-trace uses Intel PT to tell you what just happened. You give it a function name. Then, it attaches to a running process and when that function is called it will show you everything that happened for ~10ms (varies, and is partially configurable) leading up to that function call.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
   <img src="https://user-images.githubusercontent.com/128969/160190311-6b614b68-ab0a-430d-9cc5-c6759d9dc118.svg?sanitize=true#gh-dark-mode-only" width="150px"><img src="https://user-images.githubusercontent.com/128969/160190307-f3fdc6bc-f6f9-418f-8058-a5c71ed3ab44.svg?sanitize=true#gh-light-mode-only" width="150px">
-  <br/>
+  <br>
   magic-trace
 </h1>
 <p align="center">


### PR DESCRIPTION
Specifically, these three:

- [x] Fix bad indentation in README header
- [x] Use HTML 5 `<br>` instead of legacy XHTML `<br/>` in README
- [x] Make license badge in README link to `LICENSE.md`
