### PR TITLE
Rework trigger modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,15 @@ There are two ways to take a snapshot:
 
 You just did this one: <kbd>Ctrl</kbd>+<kbd>C</kbd> magic-trace. If magic trace terminates with already having taken a snapshot, it takes a snapshot.
 
-You can also trigger snapshots when the application calls a function. You can either use the default stop indicator function, `magic_trace_stop_indicator`, or supply the `-symbol` flag to magic-trace to supply your own symbol. 
+You can also trigger snapshots when the application calls a function. To do so, pass magic-trace
+the `-trigger` flag.
 
-Some ideas about where you might want to call the stop indicator:
+- `-trigger $` brings up a fuzzy-finding selector that lets you choose from all
+  symbols in your executable,
+- `-trigger SYMBOL` selects a specific, fully mangled, symbol you know ahead of time, and
+- `-trigger .` selects the default symbol `magic_trace_stop_indicator`.
+
+Stop indicators are powerful. Here are some ideas for where you might want to place one:
 
 - If you're using an asynchronous runtime, any time a scheduler cycle takes too long.
 - In a server, when a request takes a surprisingly long time.

--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -17,7 +17,6 @@ module type S = sig
     val attach_and_record
       :  Record_opts.t
       -> record_dir:string
-      -> ?filter:string
       -> Pid.t
       -> t Deferred.Or_error.t
 

--- a/core/elf.mli
+++ b/core/elf.mli
@@ -19,6 +19,9 @@ val addr_table : t -> Addr_table.t
     suitable for asking the user to disambiguate. *)
 val matching_functions : t -> Re.re -> Owee_elf.Symbol_table.Symbol.t String.Map.t
 
+val all_symbols : t -> (string * Owee_elf.Symbol_table.Symbol.t) list
+val find_symbol : t -> string -> Owee_elf.Symbol_table.Symbol.t option
+
 module Symbol_resolver : sig
   type nonrec t =
     { elf : t

--- a/src/when_to_snapshot.ml
+++ b/src/when_to_snapshot.ml
@@ -1,0 +1,35 @@
+open! Core
+
+type which_function =
+  | Use_fzf_to_select_one
+  | User_selected of string
+
+type t =
+  | Magic_trace_or_the_application_terminates
+  | Application_calls_a_function of which_function
+
+let param =
+  let open Command.Param in
+  flag
+    "-trigger"
+    (optional string)
+    ~doc:
+      "SYMBOL Decides when magic-trace takes a trace. There are three trigger modes to \
+       choose from:\n\
+       1) If you do not provide [-trigger], magic-trace takes a snapshot when either it \
+       or the application under trace ends. You can Ctrl+C magic-trace to manually \
+       trigger a snapshot.\n\
+       2) If you provide [-trigger $], magic-trace will open up a fuzzy-find dialog to \
+       help you choose a symbol to trace.\n\
+       3) If you provide [-trigger <FUNCTION NAME>], magic-trace will snapshot when the \
+       application being traced calls the given function. This takes the fully-mangled \
+       name, so if you're using anything except C, fuzzy-find mode will probably be \
+       easier to use. [-trigger .] is a shorthand for [-trigger \
+       magic_trace_stop_indicator]."
+  |> map ~f:(function
+         | None -> Magic_trace_or_the_application_terminates
+         | Some "$" -> Application_calls_a_function Use_fzf_to_select_one
+         | Some "." ->
+           Application_calls_a_function (User_selected Magic_trace.Private.stop_symbol)
+         | Some symbol -> Application_calls_a_function (User_selected symbol))
+;;

--- a/src/when_to_snapshot.mli
+++ b/src/when_to_snapshot.mli
@@ -1,0 +1,13 @@
+open! Core
+
+(* A specification of when magic-trace will take a snapshot. *)
+
+type which_function =
+  | Use_fzf_to_select_one
+  | User_selected of string
+
+type t =
+  | Magic_trace_or_the_application_terminates
+  | Application_calls_a_function of which_function
+
+val param : t Command.Param.t


### PR DESCRIPTION
Replace `-symbol` with a "trigger mode" option. To quote my own help
text:

1) If you do not provide `-trigger`, magic-trace takes a snapshot
   when either it or the application under trace ends. You can Ctrl+C
   magic-trace to manually trigger a snapshot.

2) If you provide `-trigger $`, magic-trace will open up a
   fuzzy-find dialog to help you choose a symbol to trace.

3) If you provide `-trigger <FUNCTION NAME>`, magic-trace will
   snapshot when the application being traced calls the given
   function. This takes the fully-mangled name, so if you're using
   anything except C, fuzzy-find mode will probably be easier to
   use.

`-trigger .` is a shorthand for `-trigger magic_trace_stop_indicator`.

This also removes three command-line arguments that are, in my opinion,
a mix of unnecessary and probably a bad idea to expose:

- `-delay-thresh` can be replicated by an applicationg doing this
  measurement itself. It's a very cheap operation for an application
  to add, I don't think that magic-trace is adding very much here.

- `-duration-thresh` is in the same boat as `-delay-thresh`.

- `-immediate-stop` causes issues on some kernels. Let's just remove
  it for now and revisit it in a couple years. If people actually
  want their trace to end exactly when the trigger fires, we can
  postprocess the trace output.

Please play around with this! I think it's a easier to to use... but
that's just like my opinion, man.

Fixes #60 and #69.