### PR TITLE
Clean up the CLI surface

### DIFF
--- a/core/trace_mode.ml
+++ b/core/trace_mode.ml
@@ -7,9 +7,12 @@ type t =
 [@@deriving sexp_of, compare, equal]
 
 let commands_and_docs =
-  [ Userspace, "trace-userspace", "trace userspace only"
-  ; Userspace_and_kernel, "trace-include-kernel", "trace userspace and kernel"
-  ; Kernel, "trace-kernel-only", "trace kernel only"
+  [ ( Userspace_and_kernel
+    , "trace-include-kernel"
+    , "Trace userspace and the kernel. Requires root." )
+  ; ( Kernel
+    , "trace-kernel-only"
+    , "Trace the kernel and do not trace userspace. Requires root." )
   ]
 ;;
 

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -12,9 +12,22 @@ module Record_opts = struct
 
   let param =
     let%map_open.Command multi_thread =
-      flag "-multi-thread" no_arg ~doc:"record multiple threads"
+      flag
+        "-multi-thread"
+        no_arg
+        ~doc:
+          "Records every thread of an executable, instead of only the thread whose TID \
+           is equal to the process' PID.\n\
+           Warning: this flag decreases the trace's lookback period because the kernel \
+           divides snapshot buffer resources equally across all threads."
     and full_execution =
-      flag "-full-execution" no_arg ~doc:"record full program execution"
+      flag
+        "-full-execution"
+        no_arg
+        ~doc:
+          "Record a program's full execution instead of using a snapshot ring buffer.\n\
+           Warning: The trace grows at a rate of hundreds of megabytes per second. \
+           Traces larger than 100 MiB are likely to crash the trace viewer."
     in
     { multi_thread; full_execution }
   ;;

--- a/src/tracing_tool_output.mli
+++ b/src/tracing_tool_output.mli
@@ -7,20 +7,12 @@ type t
 val param : t Command.Param.t
 
 (** After [f] writes a trace, either hosts a Perfetto UI server for the resulting file or
-      just saves it and prints a message about how to view the resulting trace.
+    just saves it and prints a message about how to view the resulting trace.
 
-      It is the responsibility of [f] to close the writer and Perfetto may fail to load
-      the trace if the writer isn't closed. *)
-val write_and_view
+    It is the responsibility of [f] to close the writer and Perfetto may fail to load
+    the trace if the writer isn't closed. *)
+val write_and_maybe_view
   :  ?num_temp_strs:int
   -> t
   -> f:(Tracing_zero.Writer.t -> 'a Deferred.Or_error.t)
   -> 'a Deferred.Or_error.t
-
-(** Used to view existing trace files in a hosted UI *)
-module Serve : sig
-  type t
-
-  val param : t Command.Param.t
-  val serve_file : t -> path:string -> unit Deferred.Or_error.t
-end

--- a/src/when_to_snapshot.ml
+++ b/src/when_to_snapshot.ml
@@ -14,18 +14,20 @@ let param =
     "-trigger"
     (optional string)
     ~doc:
-      "SYMBOL Decides when magic-trace takes a trace. There are three trigger modes to \
-       choose from:\n\
-       1) If you do not provide [-trigger], magic-trace takes a snapshot when either it \
-       or the application under trace ends. You can Ctrl+C magic-trace to manually \
-       trigger a snapshot.\n\
-       2) If you provide [-trigger ?], magic-trace will open up a fuzzy-find dialog to \
-       help you choose a symbol to trace.\n\
-       3) If you provide [-trigger <FUNCTION NAME>], magic-trace will snapshot when the \
+      "_ Selects when magic-trace takes a trace. There are three trigger modes to choose \
+       from:\n\
+       (1) If you do not provide [-trigger], magic-trace takes a snapshot when you \
+       Ctrl+C it.\n\
+       (2) If you provide [-trigger ?], magic-trace will open up a fuzzy-find dialog to \
+       help you choose a symbol to trace. Fails if you don't have the \"fzf\" binary in \
+       your PATH.\n\
+       (3) If you provide [-trigger <FUNCTION NAME>], magic-trace will snapshot when the \
        application being traced calls the given function. This takes the fully-mangled \
        name, so if you're using anything except C, fuzzy-find mode will probably be \
        easier to use. [-trigger .] is a shorthand for [-trigger \
-       magic_trace_stop_indicator]."
+       magic_trace_stop_indicator].\n\
+       (*) Regardless of trigger mode, magic-trace will always snapshot when the \
+       application terminates if it has not yet triggered for any other reason."
   |> map ~f:(function
          | None -> Magic_trace_or_the_application_terminates
          | Some "?" -> Application_calls_a_function Use_fzf_to_select_one


### PR DESCRIPTION
Document each argument and refactor the commands a little bit to support
the common pattern [-p $PID].

Fixes #37.

Help text before:

```
Attach to a process and record it until Ctrl-C, then convert the results to a viewable Fuchsia trace.

  magic_trace_bin.exe attach

=== flags ===

  [-executable-override FILE]
                             . executable to extract information from, default
                               is to use the first part of COMMAND
  [-full-execution]          . record full program execution
  [-http-port PORT]          . http server port
  [-multi-snapshot]          . allow taking multiple snapshots if possible
  [-multi-thread]            . record multiple threads
  [-output FILE]             . output file name (default: 'trace.ftf')
  [-perfetto-ui-base-directory PATH]
                             . path to Perfetto in filesystem
  [-pid PID]                 . Process to attach to. Required if you don't have
                               the "fzf" application available in your PATH.
  [-record-dir DIR]          . create this directory if necessary and put raw
                               trace data in it
  [-serve]                   . also serve the trace
  [-trace-include-kernel]    . trace userspace and kernel
  [-trace-kernel-only]       . trace kernel only
  [-trace-userspace]         . trace userspace only
  [-trigger SYMBOL]          . Decides when magic-trace takes a trace. There are
                               three trigger modes to choose from:
                               1) If you do not provide [-trigger], magic-trace
                               takes a snapshot when either it or the
                               application under trace ends. You can Ctrl+C
                               magic-trace to manually trigger a snapshot.
                               2) If you provide [-trigger ?], magic-trace will
                               open up a fuzzy-find dialog to help you choose a
                               symbol to trace.
                               3) If you provide [-trigger <FUNCTION NAME>],
                               magic-trace will snapshot when the application
                               being traced calls the given function. This takes
                               the fully-mangled name, so if you're using
                               anything except C, fuzzy-find mode will probably
                               be easier to use. [-trigger .] is a shorthand for
                               [-trigger magic_trace_stop_indicator].
  [-verbose]                 . print decoded events
  [-help], -?                . print this help text and exit
```

Help text after:

```
Traces a running process.

  magic_trace_bin.exe attach

=== flags ===

  [-full-execution]          . Record a program's full execution instead of
                               using a snapshot ring buffer.
                               Warning: The trace grows at a rate of hundreds of
                               megabytes per second. Traces larger than 100 MiB
                               are likely to crash the trace viewer.
  [-multi-snapshot]          . Take a snapshot every time the trigger is hit,
                               instead of only the first time. This flag has two
                               caveats:
                               (1) There's an ~8us performance hit every time
                               the trigger symbol is hit. If snapshots trigger
                               frequently, your application's performance may be
                               materially impacted.
                               (2) Each snapshot linearly increases the size of
                               the trace file. Large trace files may crash the
                               trace viewer.
  [-multi-thread]            . Records every thread of an executable, instead of
                               only the thread whose TID is equal to the
                               process' PID.
                               Warning: this flag decreases the trace's lookback
                               period because the kernel divides snapshot buffer
                               resources equally across all threads.
  [-output FILE]             . Where to output the trace. (default: 'trace.ftf')
  [-pid PID]                 . Process to attach to. Required if you don't have
                               the "fzf" application available in your PATH.
  [-trace-include-kernel]    . Trace userspace and the kernel. Requires root.
  [-trace-kernel-only]       . Trace the kernel and do not trace userspace.
                               Requires root.
  [-trigger _]               . Selects when magic-trace takes a trace. There are
                               three trigger modes to choose from:
                               (1) If you do not provide [-trigger], magic-trace
                               takes a snapshot when you Ctrl+C it.
                               (2) If you provide [-trigger ?], magic-trace will
                               open up a fuzzy-find dialog to help you choose a
                               symbol to trace. Fails if you don't have the
                               "fzf" binary in your PATH.
                               (3) If you provide [-trigger <FUNCTION NAME>],
                               magic-trace will snapshot when the application
                               being traced calls the given function. This takes
                               the fully-mangled name, so if you're using
                               anything except C, fuzzy-find mode will probably
                               be easier to use. [-trigger .] is a shorthand for
                               [-trigger magic_trace_stop_indicator].
                               (*) Regardless of trigger mode, magic-trace will
                               always snapshot when the application terminates
                               if it has not yet triggered for any other reason.
  [-verbose]                 . print decoded events
  [-working-directory DIR]   . Where to store intermediate files (including raw
                               perf.data files). If not provided, magic-trace
                               stores them in a subdirectory of $TMPDIR and
                               deletes them when it's done. If provided, files
                               will be stored in the given directory, creating
                               the directory if necessary, and magic-trace will
                               not delete the directory when it's done.
  [-help], -?                . print this help text and exit
```