### PR TITLE
Remove all references to janestreet-bleeding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,6 @@ jobs:
           opam switch set ${{ matrix.ocaml-version }}-flambda-musl 2>/dev/null || \
             opam switch create ${{ matrix.ocaml-version }}-flambda-musl \
               --packages=ocaml-variants.${{ matrix.ocaml-version }}+options,ocaml-option-flambda,ocaml-option-musl
-          opam repo add janestreet-bleeding https://ocaml.janestreet.com/opam-repository
 
       - run: opam install ./magic-trace.opam --deps-only
 

--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,6 @@ override_dh_clean:
 override_dh_auto_build:
 	opam init -y --bare
 	opam switch create -y 4.13.1-flambda --packages=ocaml-variants.4.13.1+options,ocaml-option-flambda
-	opam exec -- opam repo add janestreet-bleeding https://ocaml.janestreet.com/opam-repository
 	opam exec -- opam install -y ./magic-trace.opam --deps-only
 	opam exec -- dh_auto_build
 


### PR DESCRIPTION
As of the recent public-release, it's not necessary any more.