### PR TITLE
Crash with an error if perf fails

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -35,5 +35,5 @@ module type S = sig
     :  Decode_opts.t
     -> record_dir:string
     -> perf_map:Perf_map.t option
-    -> Event.t Pipe.Reader.t Deferred.Or_error.t
+    -> Decode_result.t Deferred.Or_error.t
 end

--- a/core/decode_result.ml
+++ b/core/decode_result.ml
@@ -1,0 +1,7 @@
+open Core
+open Async
+
+type t =
+  { events : Event.t Pipe.Reader.t
+  ; close_result : unit Or_error.t Deferred.t
+  }

--- a/core/decode_result.mli
+++ b/core/decode_result.mli
@@ -1,0 +1,9 @@
+open Core
+open Async
+
+(* The result of decoding events is a pipe of those events, and a deferred reason why the
+   decoder exited. *)
+type t =
+  { events : Event.t Pipe.Reader.t
+  ; close_result : unit Or_error.t Deferred.t
+  }

--- a/src/import.ml
+++ b/src/import.ml
@@ -1,6 +1,7 @@
 include struct
   open Magic_trace_core
   module Backend_intf = Backend_intf
+  module Decode_result = Decode_result
   module Elf = Elf
   module Errno = Errno
   module Event = Event

--- a/src/trace.mli
+++ b/src/trace.mli
@@ -10,6 +10,6 @@ module For_testing : sig
     -> ?debug_info:Elf.Addr_table.t
     -> Tracing_zero.Writer.t
     -> (string * Breakpoint.Hit.t) list
-    -> Event.t Pipe.Reader.t
-    -> unit Deferred.t
+    -> Decode_result.t
+    -> unit Deferred.Or_error.t
 end


### PR DESCRIPTION
magic-trace invokes perf twice: once to record a process and once to
turn that record into something magic-trace understands. Both of
those invocations can fail, and we weren't handling that well.

- If `perf record` failed, magic-trace would hang and print nothing
if the error message was long enough.

- If `perf script` failed, magic-trace would just think that there
are no events and not print any message about it.

After applying this change:

- `perf` errors are always forwarded to stderr, and
- if perf returns non-zero, magic-trace returns non-zero.

Testing: Messed up the arguments to the perf calls, one at a time,
and saw that a proper error was printed and that magic-trace
returned non-zero.

Fixes #34 and fixes #38.