### PR TITLE
Permit printing perf commands from the CLI

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -16,6 +16,7 @@ module type S = sig
 
     val attach_and_record
       :  Record_opts.t
+      -> debug_print_perf_commands:bool
       -> trace_mode:Trace_mode.t
       -> record_dir:string
       -> Pid.t
@@ -33,6 +34,7 @@ module type S = sig
 
   val decode_events
     :  Decode_opts.t
+    -> debug_print_perf_commands:bool
     -> record_dir:string
     -> perf_map:Perf_map.t option
     -> Decode_result.t Deferred.Or_error.t

--- a/src/env_vars.ml
+++ b/src/env_vars.ml
@@ -1,0 +1,11 @@
+open! Core
+open Async
+
+(* Points to a filesystem path will a copy of Perfetto. If provided, magic-trace will automatically
+  start a local HTTP server for you to view the trace. You can use this "hidden" feature to serve
+  a local copy of Perfetto if you don't want to copy trace files around. *)
+let perfetto_ui_base_directory = Unix.getenv "MAGIC_TRACE_PERFETTO_DIR"
+
+(* Turns on hidden command line options. These options are to help magic-trace developers debug
+   magic-trace, they're not generally useful. *)
+let enable_debug_options = Option.is_some (Unix.getenv "MAGIC_TRACE_DEBUG")

--- a/src/env_vars.mli
+++ b/src/env_vars.mli
@@ -1,0 +1,4 @@
+open! Core
+
+val enable_debug_options : bool
+val perfetto_ui_base_directory : string option

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -2,8 +2,6 @@ open! Core
 open! Async
 open! Import
 
-let debug_perf_commands = false
-
 (* PAGER=cat because perf spawns [less] if you get the arguments wrong, and that keeps the
    parent process alive even though it just failed. That, in turn, makes magic-trace stop
    responding to Ctrl+C. *)
@@ -57,6 +55,7 @@ module Recording = struct
 
   let attach_and_record
       { Record_opts.multi_thread; full_execution }
+      ~debug_print_perf_commands
       ~(trace_mode : Trace_mode.t)
       ~record_dir
       pid
@@ -113,7 +112,7 @@ module Recording = struct
       @ (if full_execution then [] else [ "--snapshot" ])
       @ kcore_opts
     in
-    if debug_perf_commands then Core.printf "%s\n%!" (String.concat ~sep:" " argv);
+    if debug_print_perf_commands then Core.printf "%s\n%!" (String.concat ~sep:" " argv);
     (* Perf prints output we don't care about and --quiet doesn't work for some reason *)
     let perf_pid = Core_unix.fork_exec ~env:perf_env ~prog:"perf" ~argv () in
     (* This detaches the perf process from our "process group" but not our session. This
@@ -376,7 +375,7 @@ module Perf_line = struct
   ;;
 end
 
-let decode_events () ~record_dir ~perf_map =
+let decode_events () ~debug_print_perf_commands ~record_dir ~perf_map =
   let args =
     [ "script"
     ; "-i"
@@ -387,7 +386,8 @@ let decode_events () ~record_dir ~perf_map =
     ; Perf_line.report_fields
     ]
   in
-  if debug_perf_commands then Core.printf "perf %s\n%!" (String.concat ~sep:" " args);
+  if debug_print_perf_commands
+  then Core.printf "perf %s\n%!" (String.concat ~sep:" " args);
   let%map perf_script_proc =
     Process.create_exn ~env:perf_env ~prog:"perf" ~working_dir:record_dir ~args ()
   in

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -42,12 +42,14 @@ let check_for_processor_trace_support () =
        Try again on a physical Intel machine."
 ;;
 
+let debug_flag flag =
+  if Env_vars.enable_debug_options then flag else Command.Param.return false
+;;
+
 let debug_print_perf_commands =
   let open Command.Param in
-  flag
-    "-z-print-perf-commands"
-    no_arg
-    ~doc:"For debugging magic-trace, prints perf commands."
+  flag "-z-print-perf-commands" no_arg ~doc:"Prints perf commands when they're executed."
+  |> debug_flag
 ;;
 
 let write_trace_from_events
@@ -351,10 +353,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
   let decode_flags =
     let%map_open.Command output_config = Tracing_tool_output.param
     and print_events =
-      flag
-        "-z-print-events"
-        no_arg
-        ~doc:"For debugging magic-trace, prints decoded events."
+      flag "-z-print-events" no_arg ~doc:"Prints decoded [Event.t]s." |> debug_flag
     and decode_opts = Backend.Decode_opts.param in
     { Decode_opts.output_config; decode_opts; print_events }
   ;;

--- a/src/tracing_tool_output.ml
+++ b/src/tracing_tool_output.ml
@@ -11,13 +11,8 @@ module Serve = struct
     | Disabled
     | Enabled of enabled
 
-  (* Points to a filesystem path will a copy of Perfetto. If provided, magic-trace will automatically
-    start a local HTTP server for you to view the trace. You can use this "hidden" feature to serve
-    a local copy of Perfetto if you don't want to copy trace files around. *)
-  let perfetto_ui_base_directory_env_var = Unix.getenv "MAGIC_TRACE_PERFETTO_DIR"
-
   let param =
-    match perfetto_ui_base_directory_env_var with
+    match Env_vars.perfetto_ui_base_directory with
     | None -> Command.Param.return Disabled
     | Some perfetto_ui_base_directory ->
       let%map_open.Command port =


### PR DESCRIPTION
This ability was previously configured with a global variable in the
code that requires a rebuild to switch.

I also rework how "verbose" stuff works in magic-trace. Instead of
a single "-v" flag and maybe a "-vv" flag, I opted instead to give the
two verbose flags clear names describing what they do, but start them
with -z- so they sort to the bottom of the argument list.

Also, hide debug commands behind an environment variable to avoid
polluting `-help` with flags that most users don't need.