### PR TITLE
Add more structure to Event.t

### DIFF
--- a/core/event.ml
+++ b/core/event.ml
@@ -34,15 +34,20 @@ module Thread = struct
   [@@deriving sexp, compare, hash]
 end
 
+module Location = struct
+  type t =
+    { instruction_pointer : Int64.Hex.t
+    ; symbol : Symbol.t
+    ; symbol_offset : Int.Hex.t
+    }
+  [@@deriving sexp]
+end
+
 type t =
   { thread : Thread.t
   ; time : Time_ns.Span.t
-  ; addr : Int64.Hex.t
   ; kind : Kind.t
-  ; symbol : Symbol.t
-  ; offset : Int.Hex.t
-  ; ip : Int64.Hex.t
-  ; ip_symbol : Symbol.t
-  ; ip_offset : Int.Hex.t
+  ; src : Location.t
+  ; dst : Location.t
   }
 [@@deriving sexp]

--- a/core/event.mli
+++ b/core/event.mli
@@ -34,15 +34,20 @@ module Thread : sig
   [@@deriving sexp, compare, hash]
 end
 
+module Location : sig
+  type t =
+    { instruction_pointer : int64
+    ; symbol : Symbol.t
+    ; symbol_offset : int
+    }
+  [@@deriving sexp]
+end
+
 type t =
   { thread : Thread.t
   ; time : Time_ns.Span.t
-  ; addr : int64
   ; kind : Kind.t
-  ; symbol : Symbol.t
-  ; offset : int
-  ; ip : int64
-  ; ip_symbol : Symbol.t
-  ; ip_offset : int
+  ; src : Location.t
+  ; dst : Location.t
   }
 [@@deriving sexp]

--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -278,19 +278,16 @@ let is_kernel_address addr = Int64.(addr < 0L)
 (** Write perf_events into a file as a Fuschia trace (stack events). Events should be
     collected with --itrace=b or cre, and -F pid,tid,time,flags,addr,sym,symoff as per the
     constants defined above. *)
-let write_event
-    (t : t)
-    ({ Event.thread
-     ; time
-     ; symbol
-     ; kind
-     ; addr
-     ; offset
-     ; ip = _
-     ; ip_symbol = _
-     ; ip_offset = _
-     } as event)
-  =
+let write_event (t : t) event =
+  let { Event.thread
+      ; time
+      ; kind
+      ; src = _
+      ; dst = { instruction_pointer = addr; symbol; symbol_offset = offset }
+      }
+    =
+    event
+  in
   let time = map_time t time in
   let ({ Thread_info.thread
        ; inactive_callstacks


### PR DESCRIPTION
Apply Bill's suggested renaming for `Event.t`s fields, and propagate the
new names downstream.

Also, fixed a bug where the `jmp ()` test was testing `Call`, not
`Jump`.