### PR TITLE
In help text, provide short links

### DIFF
--- a/core/timer_resolution.ml
+++ b/core/timer_resolution.ml
@@ -23,8 +23,5 @@ let param =
        (Command.Arg_type.create (fun str -> t_of_sexp (Sexp.of_string str))))
     ~doc:
       "RESOLUTION How granular timing information should be, one of Low, Normal, High, \
-       or Custom (default: Normal). Higher resolutions have higher overhead, and \
-       therefore use up more snapshot buffer space. Custom can be used to specify ad-hoc \
-       configurations, e.g. '(Custom (cyc true) (cyc_thresh 1))' (see `man 1 \
-       perf-intel-pt` for all available configuration options)."
+       or Custom (default: Normal). More info: magic-trace.org/w/t"
 ;;

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -36,9 +36,8 @@ module Record_opts = struct
       Pow2_pages.optional_flag
         "-snapshot-size"
         ~doc:
-          " Tunes the amount of data captured in a trace. By default, 4M for root or if \
-           perf_event_paranoid = -1, 256K otherwise. The trace viewer may fail to load \
-           large traces."
+          " Tunes the amount of data captured in a trace. Default: 4M if root or \
+           perf_event_paranoid < 0, 256K otherwise. More info: magic-trace.org/w/s"
     in
     { multi_thread; full_execution; snapshot_size }
   ;;


### PR DESCRIPTION
We have a proper domain with 301 redirects now. This uses short wiki
links to leave out detail from help text that not all people will
care about. Users that care about the full explaination can follow a
link.