### PR TITLE
Add well-known aliases `-p`/`-o` for `-pid`/`-output`

### DIFF
--- a/src/trace.ml
+++ b/src/trace.ml
@@ -449,6 +449,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
          flag
            "-pid"
            (optional int)
+           ~aliases:[ "-p" ]
            ~doc:
              "PID Process to attach to. Required if you don't have the \"fzf\" \
               application available in your PATH."

--- a/src/tracing_tool_output.ml
+++ b/src/tracing_tool_output.ml
@@ -121,6 +121,7 @@ let param =
     flag
       "output"
       (optional_with_default default string)
+      ~aliases:[ "o" ]
       ~doc:[%string "FILE Where to output the trace. (default: '%{default}')"]
   and serve = Serve.param in
   { serve; store_path }


### PR DESCRIPTION
These should feel more familiar for anyone coming over from `perf`.