### PR TITLE
Type breakpoint address as `int64`

### DIFF
--- a/src/breakpoint.ml
+++ b/src/breakpoint.ml
@@ -5,7 +5,7 @@ type t
 
 external create
   :  pid:int
-  -> addr:int
+  -> addr:int64
   -> single_hit:bool
   -> (t, int) result
   = "magic_breakpoint_create_stub"
@@ -17,7 +17,7 @@ module Hit = struct
     ; passed_timestamp : Time_ns.Span.t
     ; passed_val : int
     ; tid : int
-    ; ip : int
+    ; ip : Int64.Hex.t
     }
   [@@deriving sexp]
 end

--- a/src/breakpoint.mli
+++ b/src/breakpoint.mli
@@ -6,7 +6,7 @@ type t
     When that breakpoint is hit the resulting file descriptor will poll as readable.
 
     If [single_hit] is set the breakpoint will disable itself after being hit once. *)
-val breakpoint_fd : Pid.t -> addr:int -> single_hit:bool -> t Or_error.t
+val breakpoint_fd : Pid.t -> addr:int64 -> single_hit:bool -> t Or_error.t
 
 val destroy : t -> unit
 
@@ -16,7 +16,7 @@ module Hit : sig
     ; passed_timestamp : Time_ns.Span.t
     ; passed_val : int
     ; tid : int
-    ; ip : int
+    ; ip : int64
     }
   [@@deriving sexp]
 end

--- a/src/breakpoint_stubs.c
+++ b/src/breakpoint_stubs.c
@@ -76,7 +76,7 @@ CAMLprim value magic_breakpoint_create_stub(value pid, value addr,
   attr.size = sizeof(attr);
   attr.type = PERF_TYPE_BREAKPOINT;
   attr.bp_type = HW_BREAKPOINT_X;
-  attr.bp_addr = Long_val(addr);
+  attr.bp_addr = Int64_val(addr);
   attr.bp_len = sizeof(long);
   attr.sample_period = 1;
   attr.sample_type = PERF_SAMPLE_TIME | PERF_SAMPLE_IP | PERF_SAMPLE_REGS_USER |

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -234,7 +234,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
            you can accidentally incur an ~8us interrupt on every call until perf disables
            your breakpoint for exceeding the hit rate limit. *)
         let single_hit = not opts.multi_snapshot in
-        let bp = Breakpoint.breakpoint_fd pid ~addr:(Int.of_int64_exn addr) ~single_hit in
+        let bp = Breakpoint.breakpoint_fd pid ~addr ~single_hit in
         let bp = Or_error.ok_exn bp in
         let fd =
           Async_unix.Fd.create

--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -75,7 +75,7 @@ let write_hits t hits =
           Tracing.Trace.Arg.
             [ "timestamp", Int (Time_ns.Span.to_int_ns hit.timestamp)
             ; "tid", Int hit.tid
-            ; "ip", Int hit.ip
+            ; "ip", Pointer hit.ip
             ]
         in
         (* Args that are computed from captured registers are only meaningful on our


### PR DESCRIPTION
We don't currently allow putting breakpoints in kernel space, but
the types are nicer now.

Also:
- mark as `Pointer` in Fuchsia trace, so it displays as hex
- mark as `Int64.Hex.t` in `sexp_of` output

Signed-off-by: Tudor Brindus <tbrindus@janestreet.com>