### PR TITLE
Drop dependency on `ocaml-probes`

### DIFF
--- a/magic-trace.opam
+++ b/magic-trace.opam
@@ -18,7 +18,6 @@ depends: [
   "core_unix"
   "expect_test_helpers_async"
   # "fzf" vendored in lib/ for now
-  "ocaml-probes"
   "ppx_jane"
   "shell"
   # "tracing" vendored in lib/ for now

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,7 @@
  (public_name magic-trace.magic_trace_lib)
  (foreign_stubs
   (language c)
-  (names breakpoint_stubs boot_time_stubs))
+  (names breakpoint_stubs boot_time_stubs ptrace_stubs))
  (libraries core async core_unix.filename_unix fzf re shell
    core_unix.sys_unix cohttp cohttp_static_handler core_unix.signal_unix
    tracing ocaml-probes.probes_lib magic_trace magic_trace_core)

--- a/src/ptrace.ml
+++ b/src/ptrace.ml
@@ -1,0 +1,31 @@
+open! Core
+
+external ptrace_traceme : unit -> bool = "magic_ptrace_traceme"
+
+(* Same as [Caml.exit] but does not run at_exit handlers *)
+external sys_exit : int -> 'a = "caml_sys_exit"
+
+let fork_exec_stopped ~prog ~argv () =
+  let pr_set_pdeathsig = Or_error.ok_exn Linux_ext.pr_set_pdeathsig in
+  match Core_unix.fork () with
+  | `In_the_child ->
+    (* Don't outlive the magic-trace parent process. *)
+    pr_set_pdeathsig Signal.kill;
+    (* This is how we ensure the process is started in a stopped state: we mark ourselves
+       as traced, so that we receive a `SIGTRAP` after `exec*` completes. *)
+    if not (ptrace_traceme ()) then sys_exit 126;
+    never_returns
+      (try Core_unix.exec ~prog ~argv () with
+      | _ -> sys_exit 127)
+  | `In_the_parent pid ->
+    (match Core_unix.wait_untraced (`Pid pid) with
+    | _, Error (`Stop _) -> pid
+    | _, result ->
+      raise_s
+        [%message
+          "expected child to stop but it did not"
+            (pid : Pid.t)
+            (result : (unit, Core_unix.Exit_or_signal_or_stop.error) Result.t)])
+;;
+
+external resume : Pid.t -> unit = "magic_ptrace_detach"

--- a/src/ptrace.mli
+++ b/src/ptrace.mli
@@ -1,0 +1,4 @@
+open! Core
+
+val fork_exec_stopped : prog:string -> argv:string list -> unit -> Pid.t
+val resume : Pid.t -> unit

--- a/src/ptrace_stubs.c
+++ b/src/ptrace_stubs.c
@@ -1,0 +1,13 @@
+#include <sys/ptrace.h>
+
+#include <caml/mlvalues.h>
+#include <caml/unixsupport.h>
+
+CAMLprim value magic_ptrace_traceme(void) {
+  return Val_bool(!ptrace(PTRACE_TRACEME, 0, NULL, NULL));
+}
+
+CAMLprim value magic_ptrace_detach(value v_pid) {
+  ptrace(PTRACE_DETACH, Long_val(v_pid), NULL, NULL);
+  return Val_unit;
+}


### PR DESCRIPTION
We now do the `ptrace` dance ourselves.