### PR TITLE
Detect when users don't have snapshot-at-exit

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -17,6 +17,7 @@ module type S = sig
     val attach_and_record
       :  Record_opts.t
       -> debug_print_perf_commands:bool
+      -> subcommand:Subcommand.t
       -> when_to_snapshot:When_to_snapshot.t
       -> trace_mode:Trace_mode.t
       -> timer_resolution:Timer_resolution.t

--- a/core/subcommand.ml
+++ b/core/subcommand.ml
@@ -1,0 +1,6 @@
+open! Core
+
+type t =
+  | Attach
+  | Run
+[@@deriving sexp_of]

--- a/core/subcommand.mli
+++ b/core/subcommand.mli
@@ -1,0 +1,6 @@
+open! Core
+
+type t =
+  | Attach
+  | Run
+[@@deriving sexp_of]

--- a/src/import.ml
+++ b/src/import.ml
@@ -7,6 +7,7 @@ include struct
   module Event = Event
   module Perf_map = Perf_map
   module Perf_map_location = Perf_map_location
+  module Subcommand = Subcommand
   module Symbol = Symbol
   module Timer_resolution = Timer_resolution
   module Trace_mode = Trace_mode

--- a/src/perf_capabilities.mli
+++ b/src/perf_capabilities.mli
@@ -8,4 +8,5 @@ include Flags.S with type t := t
 val configurable_psb_period : t
 val kernel_tracing : t
 val kcore : t
+val snapshot_on_exit : t
 val detect_exn : unit -> t Deferred.t


### PR DESCRIPTION
Tristan mentioned that only relatively recent perfs support
snapshot-at-exit. This feature dynamically detects the user's perf
version and fails with a helpful error if they use an at-exit
trigger mode with an old version of perf.

Technically we say in the wiki that we *require* v5.4+, but I didn't
enforce that anywhere. I figure that if people really want to use
function-triggered snapshotting with an old version of perf, they should
be free to do so.