### PR TITLE
Track trace modes explicitly, don't trust perf

### DIFF
--- a/core/event.ml
+++ b/core/event.ml
@@ -1,29 +1,23 @@
 open! Core
 
-module End_kind = struct
+module Trace_state_change = struct
   type t =
-    | Call
-    | Return
-    | Syscall
-    | Sysret
-    | Iret
-    | None
-  [@@deriving sexp, compare, equal]
+    | Start
+    | End
+  [@@deriving sexp, compare]
 end
 
 module Kind = struct
   type t =
     | Call
     | Return
-    | Start
     | Syscall
     | Sysret
     | Hardware_interrupt
     | Iret
     | Decode_error
-    | End of End_kind.t
     | Jump
-  [@@deriving sexp, compare, equal]
+  [@@deriving sexp, compare]
 end
 
 module Thread = struct
@@ -46,7 +40,8 @@ end
 type t =
   { thread : Thread.t
   ; time : Time_ns.Span.t
-  ; kind : Kind.t
+  ; trace_state_change : Trace_state_change.t option [@sexp.option]
+  ; kind : Kind.t option [@sexp.option]
   ; src : Location.t
   ; dst : Location.t
   }

--- a/core/event.mli
+++ b/core/event.mli
@@ -1,29 +1,23 @@
 open! Core
 
-module End_kind : sig
+module Trace_state_change : sig
   type t =
-    | Call
-    | Return
-    | Syscall
-    | Sysret
-    | Iret
-    | None
-  [@@deriving sexp, compare, equal]
+    | Start
+    | End
+  [@@deriving sexp, compare]
 end
 
 module Kind : sig
   type t =
     | Call
     | Return
-    | Start
     | Syscall
     | Sysret
     | Hardware_interrupt
     | Iret
     | Decode_error
-    | End of End_kind.t
     | Jump
-  [@@deriving sexp, compare, equal]
+  [@@deriving sexp, compare]
 end
 
 module Thread : sig
@@ -46,7 +40,8 @@ end
 type t =
   { thread : Thread.t
   ; time : Time_ns.Span.t
-  ; kind : Kind.t
+  ; trace_state_change : Trace_state_change.t option
+  ; kind : Kind.t option
   ; src : Location.t
   ; dst : Location.t
   }

--- a/src/trace_mode_tracker.ml
+++ b/src/trace_mode_tracker.ml
@@ -1,0 +1,96 @@
+open! Core
+open! Import
+
+module Reaction = struct
+  type t =
+    | Believe
+    | Disbelieve
+  [@@deriving sexp_of]
+end
+
+type state =
+  | Tracing
+  | Not_tracing
+[@@deriving sexp_of]
+
+type t =
+  { mutable events_seen : int
+  ; mutable state : state
+  }
+[@@deriving sexp_of]
+
+let create () = { events_seen = 0; state = Tracing }
+let event_seen t = t.events_seen <- t.events_seen + 1
+
+let tr_strt t : Reaction.t =
+  event_seen t;
+  let first_event = t.events_seen = 1 in
+  if first_event
+  then Believe
+  else (
+    match t.state with
+    | Tracing -> Disbelieve
+    | Not_tracing ->
+      t.state <- Tracing;
+      Believe)
+;;
+
+let tr_end t : Reaction.t =
+  event_seen t;
+  match t.state with
+  | Tracing ->
+    t.state <- Not_tracing;
+    Believe
+  | Not_tracing -> Disbelieve
+;;
+
+let any_other_event = event_seen
+
+let process_trace_state_change t (change : Event.Trace_state_change.t option) =
+  let reaction =
+    match change with
+    | Some Start -> tr_strt t
+    | Some End -> tr_end t
+    | None ->
+      any_other_event t;
+      Believe
+  in
+  match reaction with
+  | Believe -> change
+  | Disbelieve -> None
+;;
+
+let%test_module _ =
+  (module struct
+    let p r = print_s ([%sexp_of: Reaction.t] r)
+
+    let%expect_test "believable flow" =
+      let t = create () in
+      p (tr_strt t);
+      [%expect "Believe"];
+      p (tr_end t);
+      [%expect "Believe"];
+      p (tr_strt t);
+      [%expect "Believe"];
+      p (tr_end t);
+      [%expect "Believe"]
+    ;;
+
+    let%expect_test "what are you smoking" =
+      let t = create () in
+      any_other_event t;
+      p (tr_strt t);
+      [%expect "Disbelieve"];
+      p (tr_strt t);
+      [%expect "Disbelieve"];
+      p (tr_end t);
+      [%expect "Believe"];
+      p (tr_end t);
+      [%expect "Disbelieve"];
+      p (tr_strt t);
+      [%expect "Believe"];
+      p (tr_strt t);
+      [%expect "Disbelieve"]
+    ;;
+  end)
+;;

--- a/src/trace_mode_tracker.mli
+++ b/src/trace_mode_tracker.mli
@@ -1,0 +1,18 @@
+open! Core
+open! Import
+
+(* Debounces `tr strt` and `tr end` transitions in perf's output. We need this because when perf
+   outputs (for example) two `tr strt` transitions in a row, magic-trace needs to disbelieve the
+   second one when constructing stack frames. 
+
+   We suspect, but are not sure, that the root cause of those duplicate transitions are Intel PT
+   bugs. See https://github.com/janestreet/magic-trace/issues/134 for more details. *)
+
+type t [@@deriving sexp_of]
+
+val create : unit -> t
+
+val process_trace_state_change
+  :  t
+  -> Event.Trace_state_change.t option
+  -> Event.Trace_state_change.t option

--- a/test/test.ml
+++ b/test/test.ml
@@ -50,7 +50,8 @@ end = struct
   let random_event () : Event.t =
     { thread
     ; time = time ()
-    ; kind = Call
+    ; trace_state_change = None
+    ; kind = Some Call
     ; src = random_location ()
     ; dst = random_location ()
     }
@@ -60,7 +61,7 @@ end = struct
 
   let random_event' kind symbol =
     let event = random_event () in
-    { event with kind; dst = { event.dst with symbol } }
+    { event with kind = Some kind; dst = { event.dst with symbol } }
   ;;
 
   let call () =
@@ -77,7 +78,9 @@ end = struct
       ; symbol_offset = 0
       }
     in
-    Queue.enqueue events { thread; time; kind; src = loc; dst = loc }
+    Queue.enqueue
+      events
+      { thread; time; trace_state_change = None; kind = Some kind; src = loc; dst = loc }
   ;;
 
   let ret () =


### PR DESCRIPTION
Keep a little state machine of whether or not perf is currently tracing.
If magic-trace receives a pointless event, like "tr end" when its already
not tracing, it now ignores it. Before, it would get confused and create
staircase stacks.

For more motivation, see #134. Fixes #134.

WIP awaiting confirmation that this fixes broken stacks in the rust
itch-bbo example.