### PR TITLE
Explicitly model start trace / end trace commands

### DIFF
--- a/core/event.ml
+++ b/core/event.ml
@@ -1,29 +1,16 @@
 open! Core
 
-module End_kind = struct
-  type t =
-    | Call
-    | Return
-    | Syscall
-    | Sysret
-    | Iret
-    | None
-  [@@deriving sexp, compare, equal]
-end
-
 module Kind = struct
   type t =
     | Call
     | Return
-    | Start
     | Syscall
     | Sysret
     | Hardware_interrupt
     | Iret
     | Decode_error
-    | End of End_kind.t
     | Jump
-  [@@deriving sexp, compare, equal]
+  [@@deriving sexp, compare]
 end
 
 module Thread = struct
@@ -46,7 +33,8 @@ end
 type t =
   { thread : Thread.t
   ; time : Time_ns.Span.t
-  ; kind : Kind.t
+  ; trace_state_change : Trace_state_change.t option [@sexp.option]
+  ; kind : Kind.t option [@sexp.option]
   ; src : Location.t
   ; dst : Location.t
   }

--- a/core/event.mli
+++ b/core/event.mli
@@ -1,29 +1,16 @@
 open! Core
 
-module End_kind : sig
-  type t =
-    | Call
-    | Return
-    | Syscall
-    | Sysret
-    | Iret
-    | None
-  [@@deriving sexp, compare, equal]
-end
-
 module Kind : sig
   type t =
     | Call
     | Return
-    | Start
     | Syscall
     | Sysret
     | Hardware_interrupt
     | Iret
     | Decode_error
-    | End of End_kind.t
     | Jump
-  [@@deriving sexp, compare, equal]
+  [@@deriving sexp, compare]
 end
 
 module Thread : sig
@@ -46,7 +33,8 @@ end
 type t =
   { thread : Thread.t
   ; time : Time_ns.Span.t
-  ; kind : Kind.t
+  ; trace_state_change : Trace_state_change.t option
+  ; kind : Kind.t option
   ; src : Location.t
   ; dst : Location.t
   }

--- a/core/trace_state_change.ml
+++ b/core/trace_state_change.ml
@@ -1,0 +1,6 @@
+open! Core
+
+type t =
+  | Start
+  | End
+[@@deriving sexp, compare]

--- a/core/trace_state_change.mli
+++ b/core/trace_state_change.mli
@@ -1,0 +1,6 @@
+open! Core
+
+type t =
+  | Start
+  | End
+[@@deriving sexp, compare]

--- a/src/import.ml
+++ b/src/import.ml
@@ -11,5 +11,6 @@ include struct
   module Symbol = Symbol
   module Timer_resolution = Timer_resolution
   module Trace_mode = Trace_mode
+  module Trace_state_change = Trace_state_change
   module When_to_snapshot = When_to_snapshot
 end

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -317,34 +317,49 @@ module Perf_line = struct
         let dst_symbol, dst_symbol_offset =
           parse_symbol_and_offset dst_symbol_and_offset ~addr:dst_instruction_pointer
         in
+        let starts_trace, kind =
+          match String.chop_prefix kind ~prefix:"tr strt" with
+          | None -> false, kind
+          | Some rest -> true, String.lstrip ~drop:Char.is_whitespace rest
+        in
+        let ends_trace, kind =
+          match String.chop_prefix kind ~prefix:"tr end" with
+          | None -> false, kind
+          | Some rest -> true, String.lstrip ~drop:Char.is_whitespace rest
+        in
+        let trace_state_change : Trace_state_change.t option =
+          match starts_trace, ends_trace with
+          | true, false -> Some Start
+          | false, true -> Some End
+          | false, false
+          (* "tr strt tr end" happens when someone `go run`s ./demo/demo.go. But that
+             trace is pretty broken for other reasons, so it's hard to say if this is
+             truly necessary.  Regardless, it's slightly more user friendly to show a
+             broken trace instead of crashing here. *)
+          | true, true -> None
+        in
+        let kind : Event.Kind.t option =
+          match String.strip kind with
+          | "call" -> Some Call
+          | "return" -> Some Return
+          | "jmp" -> Some Jump
+          | "jcc" -> Some Jump
+          | "syscall" -> Some Syscall
+          | "hw int" -> Some Hardware_interrupt
+          | "iret" -> Some Iret
+          | "sysret" -> Some Sysret
+          | "" -> None
+          | _ ->
+            printf "Warning: skipping unrecognized perf output: %s\n%!" line;
+            None
+        in
         { thread =
             { pid = (if pid = 0 then None else Some (Pid.of_int pid))
             ; tid = (if tid = 0 then None else Some (Pid.of_int tid))
             }
         ; time = time_lo + (time_hi * 1_000_000_000) |> Time_ns.Span.of_int_ns
-        ; kind =
-            (match String.strip kind with
-            | "call" -> Call
-            | "return" -> Return
-            | "jmp" -> Jump
-            | "jcc" -> Jump
-            | "syscall" -> Syscall
-            | "hw int" -> Hardware_interrupt
-            | "iret" -> Iret
-            | "sysret" -> Sysret
-            | "tr strt" -> Start
-            | "tr end" -> End None
-            | "tr end  call" -> End Call
-            | "tr end  return" -> End Return
-            | "tr end  syscall" -> End Syscall
-            | "tr end  iret" -> End Iret
-            | "tr end  sysret" -> End Sysret
-            (* "tr strt tr end" happens when someone `go run`s ./demo/demo.go. But that trace is
-               pretty broken for other reasons, so it's hard to say if this is truly necessary.
-               Regardless, it's slightly more user friendly to show a broken trace instead of
-               crashing here. *)
-            | "tr strt tr end" -> Jump
-            | kind -> raise_s [%message "unrecognized perf event" (kind : string)])
+        ; trace_state_change
+        ; kind
         ; src =
             { instruction_pointer = src_instruction_pointer
             ; symbol = src_symbol
@@ -397,7 +412,7 @@ module Perf_line = struct
         [%expect
           {|
           ((thread ((pid (25375)) (tid (25375)))) (time 52d4h33m11.343298468s)
-           (kind Start)
+           (trace_state_change Start)
            (src ((instruction_pointer 0x0) (symbol Unknown) (symbol_offset 0x0)))
            (dst
             ((instruction_pointer 0x7f6fce0b71d0) (symbol (From_perf __clock_gettime))

--- a/test/test.ml
+++ b/test/test.ml
@@ -50,7 +50,8 @@ end = struct
   let random_event () : Event.t =
     { thread
     ; time = time ()
-    ; kind = Call
+    ; trace_state_change = None
+    ; kind = Some Call
     ; src = random_location ()
     ; dst = random_location ()
     }
@@ -60,7 +61,7 @@ end = struct
 
   let random_event' kind symbol =
     let event = random_event () in
-    { event with kind; dst = { event.dst with symbol } }
+    { event with kind = Some kind; dst = { event.dst with symbol } }
   ;;
 
   let call () =
@@ -77,7 +78,9 @@ end = struct
       ; symbol_offset = 0
       }
     in
-    Queue.enqueue events { thread; time; kind; src = loc; dst = loc }
+    Queue.enqueue
+      events
+      { thread; time; trace_state_change = None; kind = Some kind; src = loc; dst = loc }
   ;;
 
   let ret () =


### PR DESCRIPTION
Before this change, they were incorporated into the event kind. This
change splits them out into their own variant so we can think about
them explicitly.
    
It also has the nice side effect of printing a useful error message
when a user discovers a new kind/trace combination we haven't
previously considered possible.
    
Testing: The hello-world-with-kernel-tracing test has no diff.

Depends on #145 
