### PR TITLE
Finesse decode errors back in time by 1ns

### DIFF
--- a/test/page_fault.ml
+++ b/test/page_fault.ml
@@ -6,10 +6,10 @@ let%expect_test "A page fault during demo.c" =
     {|
     1439745/1439745 2472089.651284813:   jmp                      7f59488f90f7 call_destructors+0x67 =>     7f5948676e18 _fini+0x0
      instruction trace error type 1 time 2472089.651285037 cpu -1 pid 1439745 tid 1439745 ip 0x7f5948676e18 code 7: Overflow packet
-    ->    224ns BEGIN [decode error: Overflow packet]
+    ->    223ns BEGIN [decode error: Overflow packet]
     ->          END   [decode error: Overflow packet]
     ->      0ns BEGIN _fini [inferred start time]
-    ->    224ns END   _fini
+    ->    223ns END   _fini
     1439745/1439745 2472089.651285037:   tr strt                             0 [unknown] => ffffffffae200ab0 asm_exc_page_fault+0x0
     1439745/1439745 2472089.651285037:   call                 ffffffffae200ab3 asm_exc_page_fault+0x3 => ffffffffae201310 error_entry+0x0
     1439745/1439745 2472089.651285124:   call                 ffffffffae20137a error_entry+0x6a => ffffffffae121a30 sync_regs+0x0
@@ -639,8 +639,8 @@ let%expect_test "A page fault during demo.c" =
     1439745/1439745 2472089.651286186:   return                   7f5948676e24 _fini+0xc =>     7f5948832e75 _dl_catch_exception+0xe5
     ->  1.347us END   native_iret
     END
-    ->    224ns BEGIN _dl_catch_exception [inferred start time]
-    ->    224ns BEGIN _fini [inferred start time]
+    ->    223ns BEGIN _dl_catch_exception [inferred start time]
+    ->    223ns BEGIN _fini [inferred start time]
     ->  1.373us END   _fini
     ->  1.373us END   _dl_catch_exception |}]
 ;;


### PR DESCRIPTION
A practical, but not perfect, fix for #155: If events happen with
the exact same timestamp as a decode error, stacks break.
Implement a hack to prevent that:

If and only if it doesn't reorder events, pretend the decode
error happened 1ns sooner than it actually did. That makes it have
a distinct timestamp from any following events that have the same
timestamp.

This hack fails, and the user will see broken stacks, when the
previous event has the same timestamp as the overflow error.
I haven't seen that happen before and I imagine it's quite
rare -- it would imply Intel PT was in an overflow state for an
exceedingly small amount of time.

Fixes #155.

Testing: Ran demo.c, got 5 decode errors, and the broken stacks were
fixed. Also, page_fault.ml test replicates this error condition and
it changed in the way I expect.