### PR TITLE
Add simple examples to command readmes

### DIFF
--- a/src/trace.ml
+++ b/src/trace.ml
@@ -389,6 +389,16 @@ module Make_commands (Backend : Backend_intf.S) = struct
   let run_command =
     Command.async_or_error
       ~summary:"Runs a command and traces it."
+      ~readme:(fun () ->
+        "=== examples ===\n\n\
+         # Run a process, snapshotting at ^C or exit\n\
+         magic-trace run ./program -- arg1 arg2\n\n\
+         # Run and trace all threads of a process, not just the main one, snapshotting \
+         at ^C or exit\n\
+         magic-trace run -multi-thread ./program -- arg1 arg2\n\n\
+         # Run a process, tracing its entire execution (only practical for short-lived \
+         processes)\n\
+         magic-trace run -full-execution ./program\n")
       (let%map_open.Command record_opt_fn = record_flags
        and decode_opts = decode_flags
        and debug_print_perf_commands = debug_print_perf_commands
@@ -466,6 +476,14 @@ module Make_commands (Backend : Backend_intf.S) = struct
   let attach_command =
     Command.async_or_error
       ~summary:"Traces a running process."
+      ~readme:(fun () ->
+        "=== examples ===\n\n\
+         # Fuzzy-find to select a running process to trace the main thread of, \
+         snapshotting at ^C or exit\n\
+         magic-trace attach\n\n\
+         # Fuzzy-find to select a running process and symbol to trigger on, snapshotting \
+         the next time the symbol is called\n\
+         magic-trace attach -trigger ?\n")
       (let%map_open.Command record_opt_fn = record_flags
        and decode_opts = decode_flags
        and debug_print_perf_commands = debug_print_perf_commands


### PR DESCRIPTION
Closes #144.

---

```
$ ./_build/install/default/bin/magic-trace run --help | head -n50Runs a command and traces it.

  magic-trace run COMMAND

=== examples ===

# Run a process, snapshotting at ^C or exit
magic-trace run program -- arg1 arg2!

# Run and trace all threads of a process, not just the main one, snapshotting at ^C or exit
magic-trace run -multi-thread program -- arg1 arg2

# Run a process, tracing its entire execution (only practical for short-lived processes)
magic-trace run -full-execution program

=== flags ===

  [-- ARGS]                  . Arguments for the command. Ignored by
                               magic-trace.
  [-full-execution]          . Record a program's full execution instead of
                               using a snapshot ring buffer.
                               Warning: The trace grows at a ra
```

---

```
$ ./_build/install/default/bin/magic-trace attach --help | head -n50
Traces a running process.

  magic-trace attach 

=== examples ===

# Fuzzy-find to select a running process to trace the main thread of, snapshotting at ^C or exit
magic-trace attach

# Fuzzy-find to select a running process and symbol to trigger on, snapshotting the next time the symbol is called
magic-trace attach -trigger ?

=== flags ===

  [-full-execution]          . Record a program's full execution instead of
                               using a snapshot ring buffer.
                               Warning: The trace grows at a rate of hundreds of
                               megabytes per second. The trace viewer may fail
                               to load traces larger than 100M.
```