### PR TITLE
Fix decoding failure when `-working-dir` is a relative path

### DIFF
--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -640,9 +640,7 @@ let decode_events () ~debug_print_perf_commands ~record_dir ~perf_map =
   then Core.printf "perf %s\n%!" (String.concat ~sep:" " args);
   (* CR-someday tbrindus: this should be switched over to using [perf_fork_exec] to avoid
      the [perf script] process from outliving the parent. *)
-  let%map perf_script_proc =
-    Process.create_exn ~env:perf_env ~prog:"perf" ~working_dir:record_dir ~args ()
-  in
+  let%map perf_script_proc = Process.create_exn ~env:perf_env ~prog:"perf" ~args () in
   let line_pipe = Process.stdout perf_script_proc |> Reader.lines in
   don't_wait_for
     (Reader.transfer


### PR DESCRIPTION
This was broken because we passed magic-trace cwd-relative paths, but
also changed the working directory of `perf script`. One of these had to
give, so we no longer run `perf script` inside the working directory.

This matches what we do for `perf record`.