### PR TITLE
Make --version display git version information

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -2,5 +2,14 @@
  (names magic_trace_bin)
  (public_names magic-trace)
  (libraries core magic_trace_lib core_unix.command_unix)
+ (foreign_stubs
+  (language c)
+  (names version_stubs))
  (preprocess
   (pps ppx_jane)))
+
+(rule
+ (target version_stubs.c)
+ (deps gen-versions.sh)
+ (action
+  (run %{deps} %{target})))

--- a/bin/gen-versions.sh
+++ b/bin/gen-versions.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <file to generate>"
+  exit 1
+fi
+
+VERSION="$(git describe --always --dirty --abbrev=7 --tags)"
+
+cat > "$1" <<EOF
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+
+CAMLprim value generated_hg_version(value unit __attribute__ ((unused))) {
+  return caml_copy_string("${VERSION}");
+}
+EOF


### PR DESCRIPTION
This PR adds the shell script `bin/gen-versions.sh` which generates an OCaml C stub file containing a strong `generated_hg_version` function which returns the output of `git describe --always --dirty --abbrev=7 --tags`. `core_kernel` will [call this function](https://github.com/janestreet/core_kernel/blob/236a05affa13cfc1a40926f896b883ed024f6a69/version_util/src/version_util.ml#L9-L18) when displaying the version.

Example output: `v0.0.3-56-gfbf5462`

Note that `core_kernel` provides [its own version of this function](https://github.com/janestreet/core_kernel/blob/236a05affa13cfc1a40926f896b883ed024f6a69/version_util/src/version_util_fallback_stubs.c#L12-L15) as a weak symbol, which our version overrides.

We then tell `dune` to generate this stub file by running the shell script and linking the resulting `version_stubs.c` into the executable.