### PR TITLE
Add a basic bug-report issue template

### DIFF
--- a/.github/bug.yml
+++ b/.github/bug.yml
@@ -1,0 +1,23 @@
+name: Bug report
+description: File a new bug report
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us make magic-trace better!
+
+        Please consider answering any subset of the following questions, based on what you think
+        is most relevant to your report:
+
+        - What happened?
+        - What did you expect to happen?
+        - How can we, magic-trace developers, reproduce the issue you're seeing?
+        - What version of perf userspace tools are you running? `perf --version`
+        - If you're reporting a UI bug, can you provide the trace file and/or screenshots
+          of the probem?
+        
+        Please also consider scanning the [existing set of issues](https://github.com/janestreet/magic-trace/issues)
+        for other people reporting the same thing, and checking out the
+        [FAQ](https://github.com/janestreet/magic-trace/wiki/FAQ) just in case you're running into
+        a common pitfall.


### PR DESCRIPTION
I propose we land this immediately (assuming you agree with the general idea of having one of these), then make tweaks by clicking the "edit" button on github.