### PR TITLE
Don't warn when snapshotting during full execution

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -25,7 +25,7 @@ module type S = sig
       -> Pid.t
       -> t Deferred.Or_error.t
 
-    val take_snapshot : t -> unit Or_error.t
+    val maybe_take_snapshot : t -> unit
     val finish_recording : t -> unit Deferred.Or_error.t
   end
 

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -220,11 +220,8 @@ module Recording = struct
     { can_snapshot = not full_execution; pid = perf_pid; capabilities }
   ;;
 
-  let take_snapshot { pid; can_snapshot; _ } =
-    if can_snapshot
-    then Signal_unix.send_i Signal.usr2 (`Pid pid)
-    else Core.eprintf "Warning: Ignoring snapshot during a full-execution trace\n%!";
-    Ok ()
+  let maybe_take_snapshot { pid; can_snapshot; _ } =
+    if can_snapshot then Signal_unix.send_i Signal.usr2 (`Pid pid)
   ;;
 
   let finish_recording { pid; _ } =

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -215,12 +215,10 @@ module Make_commands (Backend : Backend_intf.S) = struct
     let done_ivar = Ivar.create () in
     let snapshot_taken = ref false in
     let take_snapshot () =
-      match Backend.Recording.take_snapshot recording with
-      | Ok () ->
-        snapshot_taken := true;
-        Core.eprintf "[ Snapshot taken. ]\n%!";
-        if not opts.multi_snapshot then Ivar.fill_if_empty done_ivar ()
-      | Error e -> Core.eprint_s [%message "failed to take snapshot" (e : Error.t)]
+      Backend.Recording.maybe_take_snapshot recording;
+      snapshot_taken := true;
+      Core.eprintf "[ Snapshot taken. ]\n%!";
+      if not opts.multi_snapshot then Ivar.fill_if_empty done_ivar ()
     in
     let hits = ref [] in
     let finalize_recording () =


### PR DESCRIPTION
This warning isn't very helpful, it's really no big deal if the snapshot
symbol is hit during a full-execution run. This also fixes a minor bug
where the message is printed at the end of every full-execution complete
run because a snapshot is taken at the very end.