### PR TITLE
permit IP of 0 when parsing decode errors

### DIFF
--- a/core/event.ml
+++ b/core/event.ml
@@ -56,7 +56,7 @@ module Decode_error = struct
        Skylake test machine has it while my Tiger Lake test machine doesn't. It could
        easily be a difference between different versions of perf... *)
     ; time : Time_ns_unix.Span.Option.t
-    ; instruction_pointer : Int64.Hex.t
+    ; instruction_pointer : Int64.Hex.t option
     ; message : string
     }
   [@@deriving sexp]

--- a/core/event.mli
+++ b/core/event.mli
@@ -50,7 +50,7 @@ module Decode_error : sig
   type t =
     { thread : Thread.t
     ; time : Time_ns_unix.Span.Option.t
-    ; instruction_pointer : int64
+    ; instruction_pointer : int64 option
     ; message : string
     }
   [@@deriving sexp]


### PR DESCRIPTION
Bill found this when testing a program with the latest magic-trace