### PR TITLE
Make the default timer resolution Normal

### DIFF
--- a/core/timer_resolution.ml
+++ b/core/timer_resolution.ml
@@ -19,7 +19,7 @@ let param =
   flag
     "-timer-resolution"
     (optional_with_default
-       High
+       Normal
        (Command.Arg_type.create (fun str -> t_of_sexp (Sexp.of_string str))))
     ~doc:
       "RESOLUTION How granular timing information should be, one of Low, Normal, High, \


### PR DESCRIPTION
...to match the help text. As an aside, it's pretty confusing for the
default to not be called Normal.