### PR TITLE
Rework snapshotting

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -25,7 +25,7 @@ module type S = sig
       -> Pid.t
       -> t Deferred.Or_error.t
 
-    val maybe_take_snapshot : t -> unit
+    val maybe_take_snapshot : t -> source:[ `ctrl_c | `function_call ] -> unit
     val finish_recording : t -> unit Deferred.Or_error.t
   end
 


### PR DESCRIPTION
Make sure snapshotting always happens only once, when we expect it.
In particular, we were snapshotting on exit *and* on trigger symbol
which leads to confusing traces with large [untraced] regions.

Honestly, the real value added by this change is mostly that I
exhaustievly tested snapshotting in all the different ways, including
by simulating a perf that doesn't support snapshot-at-exit.

Testing:

- if perf supports snapshot-at-exit...
  - run
    [x] snapshot on application exit
    [x] snapshot by symbol
    [x] snapshot by Ctrl-C
  - attach
    [x] snapshot by symbol
    [x] snapshot on application exit
    [x] snapshot by Ctrl-C
- if perf doesn't support snapshot-at-exit...
  - run
    [.] snapshot on application exit (doesn't work, as expected)
    [.] snapshot by Ctrl-C (don't work; expected)
    [x] snapshot by symbol
  - attach
    [.] snapshot on application exit (doesn't work, as expected)
    [x] snapshot by Ctrl-C
    [x] snapshot by symbol