### PR TITLE
Bump owee to 0.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.opam
-          key: ${{ matrix.os }}-opam-${{ matrix.ocaml-version }}-flambda-musl-v2
+          key: ${{ matrix.os }}-opam-${{ matrix.ocaml-version }}-flambda-musl-v3
 
       - name: Install musl-compatible kernel headers
         run: |

--- a/magic-trace.opam
+++ b/magic-trace.opam
@@ -22,7 +22,7 @@ depends: [
   "shell"
   # "tracing" vendored in lib/ for now
   "dune"         {>= "2.0.0"}
-  "owee"         {>= "0.5"}
+  "owee"         {>= "0.6"}
   "re"           {>= "1.8.0"}
 ]
 synopsis: "Easy Intel Processor Trace Visualizer"


### PR DESCRIPTION
Owee 0.6 has a big speedup to the ELF parsing routine, so `magic-trace`
can pop up `fzf` much quicker now.