### PR TITLE
Stop using owee demangling

### DIFF
--- a/core/symbol.ml
+++ b/core/symbol.ml
@@ -17,17 +17,3 @@ let display_name = function
   | From_perf name -> name
   | From_perf_map { function_; _ } -> function_
 ;;
-
-let demangle_elf_name name =
-  if String.is_prefix name ~prefix:"caml_"
-  then name
-  else Owee_location.demangled_symbol name
-;;
-
-let demangle t =
-  match t with
-  | Unknown | Untraced | Returned | Syscall | From_perf_map _ ->
-    (* CR-someday cgaebel: Demangle java + other managed runtime names. *)
-    t
-  | From_perf name -> From_perf (demangle_elf_name name)
-;;

--- a/core/symbol.mli
+++ b/core/symbol.mli
@@ -10,4 +10,3 @@ type t =
 [@@deriving sexp, compare]
 
 val display_name : t -> string
-val demangle : t -> t

--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -306,7 +306,6 @@ let write_pending_event'
     time
     { Pending_event.symbol; kind }
   =
-  let symbol = Symbol.demangle symbol in
   let display_name = Symbol.display_name symbol in
   match kind with
   | Call { addr; offset; from_untraced } ->


### PR DESCRIPTION
Perfetto (and perf, for that matter) can demangle symbols themselves,
they don't need us to do it. Further, this demangler was always a little
bit incomplete -- it wouldn't tell you the line numbers of closures.

Depends on janestreet/perfetto#21