### PR TITLE
Fix debian package build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default:
 	dune build $(BUILD_ARGS)
 
 install:
-	dune install $(INSTALL_ARGS)
+	dune install $(INSTALL_ARGS) magic-trace
 
 uninstall:
 	dune uninstall $(INSTALL_ARGS)


### PR DESCRIPTION
For some reason, dune is trying to install the vendored packages. Explicitly specifying that dune install should install magic-trace fixes the build.

Example fixed run: https://github.com/quantum5/magic-trace/runs/6104035999?check_suite_focus=true