### PR TITLE
Gracefully handle owee failures in Elf.addr_table

### DIFF
--- a/core/elf.ml
+++ b/core/elf.ml
@@ -54,9 +54,7 @@ let create filename =
         }
     | _, _ -> None
   with
-  | Owee_buf.Invalid_format _ ->
-    Core.eprintf "Invalid or unknown debug info format.\n";
-    None
+  | _ -> None
 ;;
 
 let is_func sym =

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -150,7 +150,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
           with
           | None ->
             eprintf
-              "Warning: Debug info is unavaliable, so filenames and line numbers will \
+              "Warning: Debug info is unavailable, so filenames and line numbers will \
                not be available in the trace.\n\
                See \
                https://github.com/janestreet/magic-trace/wiki/Compiling-code-for-maximum-compatibility-with-magic-trace \

--- a/src/trace.mli
+++ b/src/trace.mli
@@ -7,7 +7,7 @@ val command : Command.t
 module For_testing : sig
   val write_trace_from_events
     :  trace_mode:Trace_mode.t
-    -> ?debug_info:Elf.Addr_table.t
+    -> debug_info:Elf.Addr_table.t option
     -> Tracing_zero.Writer.t
     -> (string * Breakpoint.Hit.t) list
     -> Decode_result.t

--- a/test/test.ml
+++ b/test/test.ml
@@ -135,7 +135,7 @@ let dump_using_file events =
   let destination = Tracing_zero.Destinations.iobuf_destination buf in
   let writer = Tracing_zero.Writer.Expert.create ~destination () in
   let%bind or_error =
-    write_trace_from_events ~trace_mode:Userspace writer [] decode_result
+    write_trace_from_events ~debug_info:None ~trace_mode:Userspace writer [] decode_result
   in
   ok_exn or_error;
   let parser = Tracing.Parser.create (Iobuf.read_only buf) in


### PR DESCRIPTION
Owee shouldn't have the ability to crash magic-trace. It's ~always preferably to not display debug info instead of crashing on users.