### PR TITLE
Update README.md: Getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can point magic-trace at a function such that when your application calls it
 
 # Getting started
 
-1. [Here](https://raw.githubusercontent.com/janestreet/magic-trace/master/demo/demo.c)'s a sample C program to try out. It's a slightly modified version of the example in `man 3 dlopen`. Download that, build it with `gcc -ldl demo.c -o demo`, then leave it running `./demo`. We're going to use that program to learn how `dlopen` works.
+1. [Here](https://raw.githubusercontent.com/janestreet/magic-trace/master/demo/demo.c)'s a sample C program to try out. It's a slightly modified version of the example in `man 3 dlopen`. Download that, build it with `gcc demo.c -ldl -o demo`, then leave it running `./demo`. We're going to use that program to learn how `dlopen` works.
 
 2. Run `magic-trace attach -pid $(pidof demo)`. When you see the message that it's successfully attached, wait a couple seconds and <kbd>Ctrl</kbd>+<kbd>C</kbd> `magic-trace`. It will output a file called `trace.fxt` in your working directory.
 


### PR DESCRIPTION
Moving the gcc linker option `-ldl` later.
With `gcc -ldl demo.c -o demo`, I got: 
```
/usr/bin/ld: /tmp/ccg6cKgo.o: in function `main':
demo.c:(.text+0x30): undefined reference to `dlopen'
/usr/bin/ld: demo.c:(.text+0x40): undefined reference to `dlerror'
/usr/bin/ld: demo.c:(.text+0x6d): undefined reference to `dlerror'
/usr/bin/ld: demo.c:(.text+0x80): undefined reference to `dlsym'
/usr/bin/ld: demo.c:(.text+0x89): undefined reference to `dlerror'
/usr/bin/ld: demo.c:(.text+0x11d): undefined reference to `dlclose'
collect2: error: ld returned 1 exit status
```

While `gcc demo.c -ldl -o demo` compiles.
Here's a stackoverflow answer that explains why this is happening:
https://stackoverflow.com/questions/11893996/why-does-the-order-of-l-option-in-gcc-matter/11894098#11894098 
