### PR TITLE
Added capability to attach to multiple PIDs for tracing

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -22,7 +22,7 @@ module type S = sig
       -> trace_mode:Trace_mode.t
       -> timer_resolution:Timer_resolution.t
       -> record_dir:string
-      -> Pid.t
+      -> Pid.t list
       -> t Deferred.Or_error.t
 
     val maybe_take_snapshot : t -> source:[ `ctrl_c | `function_call ] -> unit
@@ -36,9 +36,9 @@ module type S = sig
   end
 
   val decode_events
-    :  Decode_opts.t
+    :  ?perf_maps:Perf_map.Table.t
     -> debug_print_perf_commands:bool
     -> record_dir:string
-    -> perf_map:Perf_map.t option
+    -> Decode_opts.t
     -> Decode_result.t Deferred.Or_error.t
 end

--- a/core/dune
+++ b/core/dune
@@ -1,7 +1,8 @@
 (library
  (name magic_trace_core)
  (public_name magic-trace.magic_trace_core)
- (libraries core async core_unix.filename_unix magic_trace owee re)
+ (libraries core async core_unix.filename_unix expect_test_helpers_core
+   magic_trace owee re)
  (inline_tests)
  (preprocess
   (pps ppx_jane)))

--- a/core/perf_map.mli
+++ b/core/perf_map.mli
@@ -20,3 +20,19 @@ val load : Filename.t -> t option Deferred.t
 (* Looks up an address, returning the function that address is for. Returns `None` if that address
    is not in the perf-map file. *)
 val symbol : t -> addr:int64 -> Perf_map_location.t option
+
+(** Load multiple perf maps in a table. Used when tracing multiple PIDs. *)
+module Table : sig
+  type t
+
+  (** Uses default filenames for PID of [/tmp/perf-%{pid}.map]. Ignores perf
+     maps which don't exist. *)
+  val load_by_pids : Pid.t list -> t Deferred.t
+
+  (** Requires filenames to be in [perf-%{pid}.map] format in order to infer
+      PIDs and raises if any filename is not. Ignores perf maps which don't
+      exist. *)
+  val load_by_files : Filename.t list -> t Deferred.t
+
+  val symbol : t -> pid:Pid.t -> addr:int64 -> Perf_map_location.t option
+end

--- a/src/perf_tool_backend.mli
+++ b/src/perf_tool_backend.mli
@@ -4,5 +4,5 @@ open! Import
 include Backend_intf.S
 
 module Perf_line : sig
-  val to_event : string -> perf_map:Perf_map.t option -> Event.t
+  val to_event : ?perf_maps:Perf_map.Table.t -> string -> Event.t
 end

--- a/test/perf_script.ml
+++ b/test/perf_script.ml
@@ -81,7 +81,7 @@ let run ?(debug = false) ?ocaml_exception_info ~trace_mode file =
       List.iter lines ~f:(fun line ->
           if not (String.is_empty line)
           then (
-            let event = Perf_tool_backend.Perf_line.to_event line ~perf_map:None in
+            let event = Perf_tool_backend.Perf_line.to_event line in
             let event = adjust_event_time event in
             (* Most of a trace is just jumps within a single function. Those are basically
            uninteresting to magic-trace, so skip them to keep tests a little cleaner. *)


### PR DESCRIPTION
This pull request is to add the ability to have a single trace attach to multiple process ids. The interface changes to now allow `-p` to take multiple PIDs as a comma separated list which leaves the interface backward compatible. This is essentially just fed into perf which already supports tracing multiple processes. This feature is only supported by attach and there is not a method for run to run and attach to multiple processes. 

None of the other flags can be specified separately per process, but the trigger point (`-trigger`) is specified on the PID at the head of the list given since this requires the ELF file.

The logic for loading `Perf_map` was changed to allow loading a single map per process ID. For run / decode, a single perf map is still loaded either by filename or by PID.