### PR TITLE
Added ability to trace CPU frequencies with perf

### DIFF
--- a/core/event.mli
+++ b/core/event.mli
@@ -35,14 +35,30 @@ module Location : sig
 end
 
 module Ok : sig
+  module Trace : sig
+    type t =
+      { thread : Thread.t
+      ; time : Time_ns.Span.t
+      ; trace_state_change : Trace_state_change.t option
+      ; kind : Kind.t option
+      ; src : Location.t
+      ; dst : Location.t
+      }
+    [@@deriving sexp]
+  end
+
+  module Power : sig
+    type t =
+      { thread : Thread.t
+      ; time : Time_ns.Span.t
+      ; freq : int
+      }
+    [@@deriving sexp]
+  end
+
   type t =
-    { thread : Thread.t
-    ; time : Time_ns.Span.t
-    ; trace_state_change : Trace_state_change.t option
-    ; kind : Kind.t option
-    ; src : Location.t
-    ; dst : Location.t
-    }
+    | Trace of Trace.t
+    | Power of Power.t
   [@@deriving sexp]
 end
 

--- a/src/perf_tool_backend.mli
+++ b/src/perf_tool_backend.mli
@@ -4,5 +4,5 @@ open! Import
 include Backend_intf.S
 
 module Perf_line : sig
-  val to_event : ?perf_maps:Perf_map.Table.t -> string -> Event.t
+  val to_event : ?perf_maps:Perf_map.Table.t -> string -> Event.t option
 end

--- a/src/real_trace.ml
+++ b/src/real_trace.ml
@@ -12,6 +12,7 @@ let create (trace : Tracing.Trace.t) =
     let write_duration_end = Tracing.Trace.write_duration_end trace ~category:""
     let write_duration_complete = Tracing.Trace.write_duration_complete trace ~category:""
     let write_duration_instant = Tracing.Trace.write_duration_instant trace ~category:""
+    let write_counter = Tracing.Trace.write_counter trace ~category:""
   end
   in
   (module T : S_trace with type thread = Tracing.Trace.Thread.t)

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -81,7 +81,8 @@ let write_trace_from_events
   let%bind.Deferred earliest_time =
     let%map.Deferred _wait_for_first = Pipe.values_available events in
     match Pipe.peek events with
-    | Some (Ok earliest) -> earliest.time
+    | Some (Ok (Trace earliest)) -> earliest.time
+    | Some (Ok (Power earliest)) -> earliest.time
     | None | Some (Error _) -> Time_ns.Span.zero
   in
   let trace =

--- a/src/trace_writer_intf.ml
+++ b/src/trace_writer_intf.ml
@@ -35,4 +35,11 @@ module type S_trace = sig
     -> name:string
     -> time:Time_ns.Span.t
     -> unit
+
+  val write_counter
+    :  args:Tracing.Trace.Arg.t list
+    -> thread:thread
+    -> name:string
+    -> time:Time_ns.Span.t
+    -> unit
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -47,8 +47,8 @@ end = struct
     { instruction_pointer = addr (); symbol = From_perf ""; symbol_offset = offset () }
   ;;
 
-  let random_ok_event () : Event.Ok.t =
-    { thread
+  let random_ok_event () : Event.Ok.Trace.t =
+    { Event.Ok.Trace.thread
     ; time = time ()
     ; trace_state_change = None
     ; kind = Some Call
@@ -61,7 +61,7 @@ end = struct
 
   let random_event' kind symbol : Event.t =
     let event = random_ok_event () in
-    Ok { event with kind = Some kind; dst = { event.dst with symbol } }
+    Ok (Trace { event with kind = Some kind; dst = { event.dst with symbol } })
   ;;
 
   let call () =
@@ -81,13 +81,14 @@ end = struct
     Queue.enqueue
       events
       (Ok
-         { thread
-         ; time
-         ; trace_state_change = None
-         ; kind = Some kind
-         ; src = loc
-         ; dst = loc
-         })
+         (Trace
+            { thread
+            ; time
+            ; trace_state_change = None
+            ; kind = Some kind
+            ; src = loc
+            ; dst = loc
+            }))
   ;;
 
   let ret () =


### PR DESCRIPTION
Perf already reports CPU frequency through CBR (core-to-bus ratio) events. In this PR, I process these events and create a Counter track in the trace file which will show up in Perfetto. It seems to work as expected and I am able to get the CPU to downclock by using AVX instructions and generally I can see the demo just oscillate close to it's max clock speed.

A few things to note:
- There are two power events that get outputted by perf when I enable them through `perf script`. This gives psb and cbr events. I ignore the psb events (they are a heartbeat like event), but do recognize them along with cbr which we are interested in. I'm not sure if there are examples where CBR events do not give us full information on the CPUs frequency transitions and perf does allow more information to be collected, so it's possible there can be more information of use to us.
- I changed the abstraction about events from Perf to allow different types of Events, i.e. `Power`.
- Perfetto was also changed slightly to ensure this doesn't fail an assert because Perfetto seems to say `lastValues[0] = 0` for the counter track, see [here](https://github.com/janestreet/perfetto/pull/25).
- It displays above the thread it corresponds to in Perfetto (and will show one for every thread). The naming is set to 'CPU:freq (MHz)' which looks a little awkward, but was the default behavior from Perfetto. You can also toggle Perfetto to show different scales, for example min - max instead of from 0. 
- In order to enable this, you pass `-trace-power` right now. It might be reasonable to enable it by default, but this is how I currently set it.

