### PR TITLE
Add protocol to URLs embedded in help text

### DIFF
--- a/core/timer_resolution.ml
+++ b/core/timer_resolution.ml
@@ -23,5 +23,5 @@ let param =
        (Command.Arg_type.create (fun str -> t_of_sexp (Sexp.of_string str))))
     ~doc:
       "RESOLUTION How granular timing information should be, one of Low, Normal, High, \
-       or Custom (default: Normal). More info: magic-trace.org/w/t"
+       or Custom (default: Normal). For more info visit https://magic-trace.org/w/t"
 ;;

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -37,7 +37,8 @@ module Record_opts = struct
         "-snapshot-size"
         ~doc:
           " Tunes the amount of data captured in a trace. Default: 4M if root or \
-           perf_event_paranoid < 0, 256K otherwise. More info: magic-trace.org/w/s"
+           perf_event_paranoid < 0, 256K otherwise. For more info visit \
+           https://magic-trace.org/w/s"
     in
     { multi_thread; full_execution; snapshot_size }
   ;;


### PR DESCRIPTION
Having recognizable URLs inside the help text helps humans and terminal (auto-highlighting) tooling alike

Signed-off-by: Stefan Hoffmeister <stefan.hoffmeister@econos.de>