### PR TITLE
Filter trace to range

### DIFF
--- a/core/event.ml
+++ b/core/event.ml
@@ -26,7 +26,7 @@ module Location = struct
     ; symbol : Symbol.t
     ; symbol_offset : Int.Hex.t
     }
-  [@@deriving sexp]
+  [@@deriving sexp, fields]
 
   (* magic-trace has some things that aren't functions but look like they are in the trace
      (like "[untraced]" and "[syscall]") *)
@@ -93,3 +93,15 @@ let change_time (t : t) ~f : t =
     | None -> t
     | Some time -> Error { u with time = Time_ns_unix.Span.Option.some (f time) })
 ;;
+
+module With_write_info = struct
+  type outer = t [@@deriving sexp_of]
+
+  type t =
+    { event : outer
+    ; should_write : bool
+    }
+  [@@deriving sexp_of, fields]
+
+  let create ?(should_write = true) event = { event; should_write }
+end

--- a/core/event.mli
+++ b/core/event.mli
@@ -26,7 +26,7 @@ module Location : sig
     ; symbol : Symbol.t
     ; symbol_offset : int
     }
-  [@@deriving sexp]
+  [@@deriving sexp, fields]
 
   val unknown : t
   val untraced : t
@@ -73,3 +73,15 @@ type t = (Ok.t, Decode_error.t) Result.t [@@deriving sexp]
 val thread : t -> Thread.t
 val time : t -> Time_ns_unix.Span.Option.t
 val change_time : t -> f:(Time_ns.Span.t -> Time_ns.Span.t) -> t
+
+module With_write_info : sig
+  type outer = t
+
+  type t =
+    { event : outer
+    ; should_write : bool
+    }
+  [@@deriving sexp_of, fields]
+
+  val create : ?should_write:bool -> outer -> t
+end

--- a/core/symbol.ml
+++ b/core/symbol.ml
@@ -9,6 +9,10 @@ type t =
   | Syscall
 [@@deriving sexp, compare]
 
+(* [Int64.Hex] (used by [Perf_map_location]) doesn't derive [equal], so we implement
+   explicitly. *)
+let equal t1 t2 = compare t1 t2 = 0
+
 let display_name = function
   | Unknown -> "[unknown]"
   | Untraced -> "[untraced]"

--- a/core/symbol.mli
+++ b/core/symbol.mli
@@ -7,6 +7,6 @@ type t =
   | Untraced
   | Returned
   | Syscall
-[@@deriving sexp, compare]
+[@@deriving sexp, compare, equal]
 
 val display_name : t -> string

--- a/core/symbol_selection.ml
+++ b/core/symbol_selection.ml
@@ -1,0 +1,12 @@
+open! Core
+
+type t =
+  | Use_fzf_to_select_one
+  | User_selected of string
+
+let of_command_string s =
+  match s with
+  | "?" -> Use_fzf_to_select_one
+  | "." -> User_selected Magic_trace.Private.stop_symbol
+  | s -> User_selected s
+;;

--- a/core/symbol_selection.mli
+++ b/core/symbol_selection.mli
@@ -1,0 +1,7 @@
+open! Core
+
+type t =
+  | Use_fzf_to_select_one
+  | User_selected of string
+
+val of_command_string : string -> t

--- a/core/trace_filter.ml
+++ b/core/trace_filter.ml
@@ -1,0 +1,37 @@
+open! Core
+
+module Unevaluated = struct
+  type t =
+    { start_symbol : Symbol_selection.t
+    ; stop_symbol : Symbol_selection.t
+    }
+  [@@deriving fields]
+
+  (* Accepts '(foo bar)', returns { start_symbol = User_selected "foo"; stop_symbol = User_selected = "bar" } *)
+  let arg_type =
+    Command.Param.Arg_type.create (fun s ->
+        let start_symbol, stop_symbol =
+          Sexp.of_string s
+          |> Tuple2.t_of_sexp String.t_of_sexp String.t_of_sexp
+          |> Tuple2.map ~f:Symbol_selection.of_command_string
+        in
+        { start_symbol; stop_symbol })
+  ;;
+end
+
+type t =
+  { start_symbol : string
+  ; stop_symbol : string
+  }
+[@@deriving sexp, fields]
+
+let param =
+  let open Command.Param in
+  flag
+    "-filter"
+    (optional Unevaluated.arg_type)
+    ~doc:
+      "_ [-filter \"(<START> <STOP>)\"] restricts the output of magic-trace to events \
+       ocurring between consecutive occurences of START and STOP. If either function is \
+       not called in the trace, no output will be produced."
+;;

--- a/core/trace_filter.mli
+++ b/core/trace_filter.mli
@@ -1,0 +1,19 @@
+open! Core
+
+(* A specification of a trace filter for magic-trace *)
+
+module Unevaluated : sig
+  type t =
+    { start_symbol : Symbol_selection.t
+    ; stop_symbol : Symbol_selection.t
+    }
+  [@@deriving fields]
+end
+
+type t =
+  { start_symbol : string
+  ; stop_symbol : string
+  }
+[@@deriving sexp, fields]
+
+val param : Unevaluated.t option Command.Param.t

--- a/core/when_to_snapshot.ml
+++ b/core/when_to_snapshot.ml
@@ -1,12 +1,8 @@
 open! Core
 
-type which_function =
-  | Use_fzf_to_select_one
-  | User_selected of string
-
 type t =
   | Magic_trace_or_the_application_terminates
-  | Application_calls_a_function of which_function
+  | Application_calls_a_function of Symbol_selection.t
 
 let param =
   let open Command.Param in
@@ -30,8 +26,6 @@ let param =
        application terminates if it has not yet triggered for any other reason."
   |> map ~f:(function
          | None -> Magic_trace_or_the_application_terminates
-         | Some "?" -> Application_calls_a_function Use_fzf_to_select_one
-         | Some "." ->
-           Application_calls_a_function (User_selected Magic_trace.Private.stop_symbol)
-         | Some symbol -> Application_calls_a_function (User_selected symbol))
+         | Some input ->
+           Application_calls_a_function (Symbol_selection.of_command_string input))
 ;;

--- a/core/when_to_snapshot.mli
+++ b/core/when_to_snapshot.mli
@@ -2,12 +2,8 @@ open! Core
 
 (* A specification of when magic-trace will take a snapshot. *)
 
-type which_function =
-  | Use_fzf_to_select_one
-  | User_selected of string
-
 type t =
   | Magic_trace_or_the_application_terminates
-  | Application_calls_a_function of which_function
+  | Application_calls_a_function of Symbol_selection.t
 
 val param : t Command.Param.t

--- a/src/for_range.ml
+++ b/src/for_range.ml
@@ -1,0 +1,103 @@
+open! Core
+open! Async
+open! Import
+
+module Symbol_hit = struct
+  module Kind = struct
+    type t =
+      | Start
+      | Stop
+    [@@deriving sexp_of]
+  end
+
+  type t =
+    { kind : Kind.t
+    ; symbol : Symbol.t
+    ; time : Time_ns.Span.t
+    }
+  [@@deriving sexp_of]
+end
+
+let range_hit_times ~decode_events ~range_symbols =
+  let open Deferred.Or_error.Let_syntax in
+  let%bind { Decode_result.events; _ } = decode_events () in
+  Deferred.List.map events ~f:(fun events ->
+      let { Trace_filter.start_symbol; stop_symbol } = range_symbols in
+      let is_start symbol = String.(Symbol.display_name symbol = start_symbol) in
+      let is_stop symbol = String.(Symbol.display_name symbol = stop_symbol) in
+      Pipe.filter_map events ~f:(function
+          | Error _ | Ok { data = Power _; _ } -> None
+          | Ok { data = Trace trace; time; _ } ->
+            (match trace.kind with
+            | Some Call ->
+              let symbol = trace.dst.symbol in
+              if is_start symbol
+              then Some { Symbol_hit.kind = Start; symbol; time }
+              else if is_stop symbol
+              then Some { Symbol_hit.kind = Stop; symbol; time }
+              else None
+            | _ -> None)
+          | Ok { data = Sample { callstack }; time; _ } ->
+            List.rev callstack
+            |> List.fold ~init:None ~f:(fun acc call ->
+                   match acc, call with
+                   | None, { symbol; _ } when is_start symbol ->
+                     Some { Symbol_hit.kind = Start; symbol; time }
+                   | None, { symbol; _ } when is_stop symbol ->
+                     Some { Symbol_hit.kind = Stop; symbol; time }
+                   | acc, _ -> acc))
+      |> Pipe.to_list)
+  |> Deferred.map ~f:Or_error.return
+;;
+
+let remove_unmatched_hits (hits : Symbol_hit.t list) =
+  let rec remove_unmatched_hits' ~accum hits =
+    match hits with
+    | [] -> accum
+    | [ { Symbol_hit.kind = Start; _ } ] -> accum
+    | [ { Symbol_hit.kind = Stop; _ } ] -> accum
+    | first :: second :: rest ->
+      (match first.kind, second.kind with
+      | _, Start -> remove_unmatched_hits' ~accum (second :: rest)
+      | Stop, Stop -> remove_unmatched_hits' ~accum rest
+      | Start, Stop -> remove_unmatched_hits' ~accum:(second :: first :: accum) rest)
+  in
+  remove_unmatched_hits' ~accum:[] hits |> List.rev
+;;
+
+(* Calls provided [decode_event] and marks events if they should be written (are
+   in-between a start and stop symbol). If there are multiple calls to
+   [range_start_symbol] at the same time, they will all be marked [should_write = true]. *)
+let decode_events_and_annotate ~decode_events ~range_symbols =
+  let open Deferred.Or_error.Let_syntax in
+  let%bind { Decode_result.events; close_result } = decode_events ()
+  and range_hit_times = range_hit_times ~decode_events ~range_symbols in
+  let hit_sequences = List.map range_hit_times ~f:remove_unmatched_hits in
+  let events =
+    List.zip_exn events hit_sequences
+    |> List.map ~f:(fun (events, hit_sequence) ->
+           Pipe.folding_map
+             events
+             ~init:(hit_sequence, false)
+             ~f:(fun (hits, in_filtered_region) event ->
+               let hits, in_filtered_region =
+                 match hits with
+                 | [] -> hits, in_filtered_region
+                 | hd :: tl ->
+                   (match event with
+                   | Ok { data = Trace { kind = Some Call; dst; _ }; time; _ }
+                     when Time_ns_unix.Span.(time = hd.time)
+                          && Symbol.equal dst.symbol hd.symbol ->
+                     tl, not in_filtered_region
+                   | Ok { data = Sample _; time; _ }
+                     when Time_ns_unix.Span.(time = hd.time) -> tl, not in_filtered_region
+                   | Ok { data = Trace _; _ }
+                   | Ok { data = Sample _; _ }
+                   | Ok { data = Power _; _ }
+                   | Error _ -> hits, in_filtered_region)
+               in
+               ( (hits, in_filtered_region)
+               , Event.With_write_info.create ~should_write:in_filtered_region event )))
+  in
+  return (events, close_result)
+;;

--- a/src/for_range.mli
+++ b/src/for_range.mli
@@ -1,0 +1,9 @@
+open! Core
+open! Async
+open! Import
+
+val decode_events_and_annotate
+  :  decode_events:(unit -> Import.Decode_result.t Deferred.Or_error.t)
+  -> range_symbols:Trace_filter.t
+  -> (Event.With_write_info.t Async.Pipe.Reader.t list * unit Deferred.Or_error.t)
+     Deferred.Or_error.t

--- a/src/import.ml
+++ b/src/import.ml
@@ -15,5 +15,7 @@ include struct
   module Trace_scope = Trace_scope
   module Trace_state_change = Trace_state_change
   module Util = Util
+  module Symbol_selection = Symbol_selection
   module When_to_snapshot = When_to_snapshot
+  module Trace_filter = Trace_filter
 end

--- a/src/trace.mli
+++ b/src/trace.mli
@@ -5,12 +5,19 @@ open! Import
 val command : Command.t
 
 module For_testing : sig
+  val get_events_pipe
+    :  ?range_symbols:Trace_filter.t
+    -> events:Event.t list
+    -> unit
+    -> Event.With_write_info.t Pipe.Reader.t Deferred.t
+
   val write_trace_from_events
     :  ?ocaml_exception_info:Ocaml_exception_info.t
     -> trace_scope:Trace_scope.t
     -> debug_info:Elf.Addr_table.t option
     -> Tracing_zero.Writer.t
-    -> (string * Breakpoint.Hit.t) list
-    -> Decode_result.t
+    -> hits:(string * Breakpoint.Hit.t) list
+    -> events:Event.With_write_info.t Pipe.Reader.t list
+    -> close_result:unit Deferred.Or_error.t
     -> unit Deferred.Or_error.t
 end

--- a/src/trace_writer.mli
+++ b/src/trace_writer.mli
@@ -32,7 +32,7 @@ val create_expert
   -> (module Trace with type thread = _)
   -> t
 
-val write_event : t -> Event.t -> unit
+val write_event : t -> Event.With_write_info.t -> unit
 
 (** Updates interal data structures when trace ends. If [to_time] is passed, will
    shift to new start time which is useful when writing out multiple snapshots

--- a/test/perf_script.ml
+++ b/test/perf_script.ml
@@ -95,6 +95,7 @@ let run ?(debug = false) ?ocaml_exception_info ~trace_scope file =
             match lines with
             | [ line ] -> printf "%s\n" line
             | lines -> print_s [%message (lines : string list)]);
+          let event = Event.With_write_info.create ~should_write:true event in
           Trace_writer.write_event trace_writer event);
       printf "END\n";
       Trace_writer.end_of_trace trace_writer)


### PR DESCRIPTION
Adds a new flag `-filter "(<start> <stop>)"` to magic trace. With this flag, the trace is trimmed to only include events that occur between `start` (inclusive) and `stop` (exclusive) (#81). If either symbol doesn't appear in the trace, no output is produced. In multi-snapshot mode, the trace only includes regions between consecutive `start` and `stop` calls. The `-filter` flag is compatible with the same modes as the `-trigger` flag.

When producing a `.sexp` output, only events that occur in the filtered region are emitted. When producing a fuchsia `.fxt` output, the full available callstack around the filtered region is reconstructed. Active stack frames at the beginning of the filtered region have the time `start` was called as their inferred start time.