### PR TITLE
Improved speed of hex parsing in more places

### DIFF
--- a/core/perf_map.ml
+++ b/core/perf_map.ml
@@ -12,9 +12,6 @@ let perf_map_re =
   Re.Posix.re {|^([0-9a-fA-F]+) ([0-9a-fA-F]+) (.*)$|} |> Re.compile
 ;;
 
-let hex_to_int s = Int.Hex.of_string ("0x" ^ s)
-let hex_to_int64 s = Int64.Hex.of_string ("0x" ^ s)
-
 let parse_line line =
   (* empty string for the last line in a file *)
   if String.is_empty line
@@ -23,8 +20,10 @@ let parse_line line =
     try
       match Re.Group.all (Re.exec perf_map_re line) with
       | [| _; start_addr; size; function_ |] ->
-        let start_addr = hex_to_int64 start_addr in
-        (start_addr, { Perf_map_location.start_addr; size = hex_to_int size; function_ })
+        let start_addr = Util.int64_of_hex_string start_addr in
+        ( start_addr
+        , { Perf_map_location.start_addr; size = Util.int_of_hex_string size; function_ }
+        )
         |> Some
       | _ -> failwith "doesn't match regex"
     with

--- a/core/util.ml
+++ b/core/util.ml
@@ -1,0 +1,62 @@
+open! Core
+
+let intable_of_hex_string
+    (type a)
+    (module M : Int_intf.S with type t = a)
+    ?(remove_hex_prefix = false)
+    str
+  =
+  (* Bit hacks for fast parsing of hex strings.
+   *
+   * Note that in ASCII, ('1' | 'a' | 'A') & 0xF = 1.
+   *
+   * So for each character, take the bottom 4 bits, and add 9 if it's
+   * not a digit. *)
+  let res = ref (M.of_int_exn 0) in
+  let fifteen = M.of_int_exn 0xF in
+  let eight = M.of_int_exn 0x8 in
+  for i = if remove_hex_prefix then 2 else 0 to String.length str - 1 do
+    let open M in
+    let c = of_int_exn (Char.to_int (String.unsafe_get str i)) in
+    res := (!res lsl 4) lor ((c land fifteen) + ((c lsr 6) lor ((c lsr 3) land eight)))
+  done;
+  !res
+;;
+
+let int64_of_hex_string = intable_of_hex_string (module Int64)
+let int_of_hex_string = intable_of_hex_string (module Int)
+
+let%test_module _ =
+  (module struct
+    open Core
+
+    let check ?remove_hex_prefix str =
+      print_s
+        [%message
+          ""
+            ~int64:(int64_of_hex_string ?remove_hex_prefix str : Int64.Hex.t)
+            ~int:(int_of_hex_string ?remove_hex_prefix str : Int.Hex.t)]
+    ;;
+
+    let%expect_test "int64 hex parsing" =
+      check ~remove_hex_prefix:true "0x7f9db48c1d80";
+      [%expect {|
+        ((int64 0x7f9db48c1d80) (int 0x7f9db48c1d80)) |}];
+      check "7f9db48c1d80";
+      [%expect {|
+        ((int64 0x7f9db48c1d80) (int 0x7f9db48c1d80)) |}];
+      check "fF";
+      [%expect {|
+        ((int64 0xff) (int 0xff)) |}];
+      check "f0f";
+      [%expect {|
+        ((int64 0xf0f) (int 0xf0f)) |}];
+      check "fA0f";
+      [%expect {|
+          ((int64 0xfa0f) (int 0xfa0f)) |}];
+      check "0";
+      [%expect {|
+        ((int64 0x0) (int 0x0)) |}]
+    ;;
+  end)
+;;

--- a/core/util.mli
+++ b/core/util.mli
@@ -1,0 +1,4 @@
+open! Core
+
+val int64_of_hex_string : ?remove_hex_prefix:bool -> string -> int64
+val int_of_hex_string : ?remove_hex_prefix:bool -> string -> int

--- a/src/import.ml
+++ b/src/import.ml
@@ -1,6 +1,7 @@
 include struct
   open Magic_trace_core
   module Backend_intf = Backend_intf
+  module Collection_mode = Collection_mode
   module Decode_result = Decode_result
   module Elf = Elf
   module Errno = Errno
@@ -12,7 +13,7 @@ include struct
   module Symbol = Symbol
   module Timer_resolution = Timer_resolution
   module Trace_scope = Trace_scope
-  module Collection_mode = Collection_mode
   module Trace_state_change = Trace_state_change
+  module Util = Util
   module When_to_snapshot = When_to_snapshot
 end


### PR DESCRIPTION
This addresses issue #93. Although #150 implemented fast hex string parsing, when I was magic-tracing magic-trace, I noticed this in the trace:
![image](https://user-images.githubusercontent.com/15175891/175398604-f62a6da2-90f1-43ca-b8ae-e35349a7970c.png)

This section of the trace entirely occurs because of calling `Int.Hex.of_string offset` within `parse_symbol_and_offset`. And this tends to take around 200-250 ns. Since this occurs about once per line in the `perf.data` file, the trace I ran this on executed this around 1.8 million times which should save a few hundred ms (out of total time of a few seconds).

Here are the traces after and before this change (respectively) zoomed in on 3 decodes (which shows 3 executions of `parse_symbol_and_offset`) of a perf line containing an entry of the callstack sampled. The former is just below 2 us and the latter is around 2.6 us. However it is clear that most of the remaining time is now spent on evaluating regex in the former.

![image](https://user-images.githubusercontent.com/15175891/175397340-8a78c154-96c3-4e3c-a19b-34b08d448b40.png)
![image](https://user-images.githubusercontent.com/15175891/175398274-c3e15695-5c5d-4bd3-bf7e-297163545af4.png)

In regards to implementation, I extracted these functions out to a `Util` module and used them when possible else where in magic-trace (although only the offset calculation is expensive because it is called a lot, but it seems reasonable to use them if possible). I used first class modules to abstract around `Int` and `Int64`.