### PR TITLE
Added warnings to `-callgraph-mode` and added option for stitched LBR.

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -12,6 +12,10 @@ module type S = sig
   end
 
   module Recording : sig
+    module Data : sig
+      type t [@@deriving sexp]
+    end
+
     type t
 
     val attach_and_record
@@ -25,7 +29,7 @@ module type S = sig
       -> record_dir:string
       -> collection_mode:Collection_mode.t
       -> Pid.t list
-      -> t Deferred.Or_error.t
+      -> (t * Data.t) Deferred.Or_error.t
 
     val maybe_take_snapshot : t -> source:[ `ctrl_c | `function_call ] -> unit
     val finish_recording : t -> unit Deferred.Or_error.t
@@ -40,6 +44,9 @@ module type S = sig
   val decode_events
     :  ?perf_maps:Perf_map.Table.t
     -> debug_print_perf_commands:bool
+    -> recording_data:Recording.Data.t option
+         (** This parameter is passed to allow [decode_events] to depend
+             on information or configuration from [attach_and_record]. *)
     -> record_dir:string
     -> collection_mode:Collection_mode.t
     -> Decode_opts.t

--- a/src/callgraph_mode.ml
+++ b/src/callgraph_mode.ml
@@ -1,13 +1,17 @@
 open! Core
 
 type t =
-  | Last_branch_record
+  | Last_branch_record of { stitched : bool [@sexp.default true] }
   | Frame_pointers
   | Dwarf
 [@@deriving sexp]
 
 let of_string = function
-  | "lbr" -> Last_branch_record
+  (* Kept the short names to match naming of callgraph modes from perf
+     (lbr/dwarf/fp) for users who are familiar with perf. [lbr-no-stitch] is not
+     from perf, but added as a shorter option. *)
+  | "lbr" -> Last_branch_record { stitched = true }
+  | "lbr-no-stitch" -> Last_branch_record { stitched = false }
   | "fp" -> Frame_pointers
   | "dwarf" -> Dwarf
   | str -> t_of_sexp (Sexp.of_string str)
@@ -20,13 +24,22 @@ let param =
     (optional (Command.Arg_type.create of_string))
     ~doc:
       " When magic-trace is running with sampling collection mode, this sets how it \
-       should reconstruct callstacks. The options are Last_branch_record (lbr), Dwarf \
-       (dwarf), and Frame_pointers (fp). Will default to Last_branch_record if supported \
-       and Dwarf otherwise."
+       should reconstruct callstacks. The options are [lbr]/[lbr-no-stitch]/[dwarf]/[fp] \
+       or a sexp. Will default to [lbr] is available and [dwarf] otherwise. For more \
+       info: https://magic-trace.org/w/c"
 ;;
 
-let to_perf_string = function
-  | Last_branch_record -> "lbr"
-  | Frame_pointers -> "fp"
-  | Dwarf -> "dwarf"
+let to_perf_record_args = function
+  | Some (Last_branch_record _) -> [ "--call-graph"; "lbr" ]
+  | Some Frame_pointers -> [ "--call-graph"; "fp" ]
+  | Some Dwarf -> [ "--call-graph"; "dwarf" ]
+  | None -> []
+;;
+
+let to_perf_script_args = function
+  | Some (Last_branch_record { stitched = true }) -> [ "--stitch-lbr" ]
+  | Some (Last_branch_record { stitched = false })
+  | Some Frame_pointers
+  | Some Dwarf
+  | None -> []
 ;;

--- a/src/callgraph_mode.mli
+++ b/src/callgraph_mode.mli
@@ -1,10 +1,11 @@
 open! Core
 
 type t =
-  | Last_branch_record
+  | Last_branch_record of { stitched : bool }
   | Frame_pointers
   | Dwarf
 [@@deriving sexp]
 
 val param : t option Command.Param.t
-val to_perf_string : t -> string
+val to_perf_record_args : t option -> string list
+val to_perf_script_args : t option -> string list


### PR DESCRIPTION
This feature has two changes related to `callgraph_mode`.

* Based on user feedback from #224, I added warnings when the `-callgraph-mode` defaults to either `Dwarf` or `Last_branch_record` to notify the user of potential drawbacks from such selection. These warnings only show if they do not explicitly set the flag.
* Added a fourth option to run with `Last_branch_record { stitched = true }` which calls `perf report --call-graph lbr` and `perf script --stitch-lbr`. There are a few design decisions here though. First I decided to add it as a variant of `Callgraph_mode` for simplicity of interface for the user. However this has the awkward effect of this now being a parameter needed for both decoding and recording (which `Backend_intf` doesn't support). I would think this could perhaps be useful in other scenarios and so instead of pulling this out to `trace.ml` I decided to add a way for `decode_events` to have access to a `Recording.Data.t` record. Open to alternative ideas though.

I also added a wiki page to document the options for `-callgraph-mode`. This is not in the PR, but here is the link to the wiki repo: https://github.com/Lamoreauxaj/magic-trace.wiki.git. See [this page](https://github.com/Lamoreauxaj/magic-trace/wiki/Sampling-callgraph-modes). If this PR is merged, this wiki page would need to be merged too (I referenced it in the cli help documentation). And since I referenced it, the domain would need to redirect to the wiki page.