### PR TITLE
Added support to run perf with dlfilter which filters out jumps within same function

### DIFF
--- a/magic-trace.opam
+++ b/magic-trace.opam
@@ -17,6 +17,7 @@ depends: [
   "core"
   "core_unix"
   "expect_test_helpers_async"
+  "crunch"
   "ppx_jane"
   "shell"
   "dune"         {>= "2.0.0"}

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,14 @@
+(rule
+ (targets perf_dlfilter.ml)
+ (deps
+  (:dep perf_dlfilter.c))
+ (action
+  (progn
+   (run mkdir -p dlfilter)
+   (run %{bin:gcc} -c -fpic %{dep})
+   (run %{bin:gcc} -shared -o dlfilter/perf_dlfilter.so perf_dlfilter.o)
+   (run %{bin:ocaml-crunch} -m plain dlfilter -o perf_dlfilter.ml))))
+
 (library
  (name magic_trace_lib)
  (public_name magic-trace.magic_trace_lib)

--- a/src/perf_capabilities.ml
+++ b/src/perf_capabilities.ml
@@ -7,6 +7,7 @@ let kernel_tracing = bit 1
 let kcore = bit 2
 let snapshot_on_exit = bit 3
 let last_branch_record = bit 4
+let dlfilter = bit 5
 
 include Flags.Make (struct
   let allow_intersecting = false
@@ -18,6 +19,7 @@ include Flags.Make (struct
     ; kernel_tracing, "kernel_tracing"
     ; kcore, "kcore"
     ; last_branch_record, "last_branch_record"
+    ; dlfilter, "dlfilter"
     ]
   ;;
 end)
@@ -94,6 +96,9 @@ let supports_kcore = kernel_version_at_least ~major:5 ~minor:5
 (* Added in kernel commit ce7b0e4, which made it into 5.4. *)
 let supports_snapshot_on_exit = kernel_version_at_least ~major:5 ~minor:4
 
+(* Added in kernel commit 291961f, which made it into 5.14. *)
+let supports_dlfilter = kernel_version_at_least ~major:5 ~minor:14
+
 let detect_exn () =
   let%bind perf_version_proc = Process.create_exn ~prog:"perf" ~args:[ "--version" ] () in
   let%map version_string = Reader.contents (Process.stdout perf_version_proc) in
@@ -105,4 +110,5 @@ let detect_exn () =
   |> set_if (supports_kcore version) kcore
   |> set_if (supports_snapshot_on_exit version) snapshot_on_exit
   |> set_if (supports_last_branch_record ()) last_branch_record
+  |> set_if (supports_dlfilter version) dlfilter
 ;;

--- a/src/perf_capabilities.mli
+++ b/src/perf_capabilities.mli
@@ -10,4 +10,5 @@ val kernel_tracing : t
 val kcore : t
 val snapshot_on_exit : t
 val last_branch_record : t
+val dlfilter : t
 val detect_exn : unit -> t Deferred.t

--- a/src/perf_dlfilter.c
+++ b/src/perf_dlfilter.c
@@ -1,0 +1,22 @@
+#include "perf_dlfilter.h"
+#include <string.h>
+
+struct perf_dlfilter_fns perf_dlfilter_fns = {0};
+
+int start(void **data, void *ctx);
+int stop(void *data, void *ctx);
+int filter_event(void *data, const struct perf_dlfilter_sample *sample,
+                 void *ctx);
+int filter_event_early(void *data, const struct perf_dlfilter_sample *sample,
+                       void *ctx) {
+  const struct perf_dlfilter_al *resolved_ip =
+      perf_dlfilter_fns.resolve_ip(ctx);
+  const struct perf_dlfilter_al *resolved_addr =
+      perf_dlfilter_fns.resolve_addr(ctx);
+  if (!resolved_ip || !resolved_ip->sym || !resolved_addr ||
+      !resolved_addr->sym ||
+      strcmp(resolved_ip->sym, resolved_addr->sym) == 0) {
+    return 1;
+  }
+  return 0;
+}

--- a/src/perf_dlfilter.h
+++ b/src/perf_dlfilter.h
@@ -1,0 +1,150 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * perf_dlfilter.h: API for perf --dlfilter shared object
+ * Copyright (c) 2021, Intel Corporation.
+ */
+#ifndef _LINUX_PERF_DLFILTER_H
+#define _LINUX_PERF_DLFILTER_H
+
+#include <linux/perf_event.h>
+#include <linux/types.h>
+
+/* Definitions for perf_dlfilter_sample flags */
+enum {
+	PERF_DLFILTER_FLAG_BRANCH	= 1ULL << 0,
+	PERF_DLFILTER_FLAG_CALL		= 1ULL << 1,
+	PERF_DLFILTER_FLAG_RETURN	= 1ULL << 2,
+	PERF_DLFILTER_FLAG_CONDITIONAL	= 1ULL << 3,
+	PERF_DLFILTER_FLAG_SYSCALLRET	= 1ULL << 4,
+	PERF_DLFILTER_FLAG_ASYNC	= 1ULL << 5,
+	PERF_DLFILTER_FLAG_INTERRUPT	= 1ULL << 6,
+	PERF_DLFILTER_FLAG_TX_ABORT	= 1ULL << 7,
+	PERF_DLFILTER_FLAG_TRACE_BEGIN	= 1ULL << 8,
+	PERF_DLFILTER_FLAG_TRACE_END	= 1ULL << 9,
+	PERF_DLFILTER_FLAG_IN_TX	= 1ULL << 10,
+	PERF_DLFILTER_FLAG_VMENTRY	= 1ULL << 11,
+	PERF_DLFILTER_FLAG_VMEXIT	= 1ULL << 12,
+};
+
+/*
+ * perf sample event information (as per perf script and <linux/perf_event.h>)
+ */
+struct perf_dlfilter_sample {
+	__u32 size; /* Size of this structure (for compatibility checking) */
+	__u16 ins_lat;		/* Refer PERF_SAMPLE_WEIGHT_TYPE in <linux/perf_event.h> */
+	__u16 p_stage_cyc;	/* Refer PERF_SAMPLE_WEIGHT_TYPE in <linux/perf_event.h> */
+	__u64 ip;
+	__s32 pid;
+	__s32 tid;
+	__u64 time;
+	__u64 addr;
+	__u64 id;
+	__u64 stream_id;
+	__u64 period;
+	__u64 weight;		/* Refer PERF_SAMPLE_WEIGHT_TYPE in <linux/perf_event.h> */
+	__u64 transaction;	/* Refer PERF_SAMPLE_TRANSACTION in <linux/perf_event.h> */
+	__u64 insn_cnt;	/* For instructions-per-cycle (IPC) */
+	__u64 cyc_cnt;		/* For instructions-per-cycle (IPC) */
+	__s32 cpu;
+	__u32 flags;		/* Refer PERF_DLFILTER_FLAG_* above */
+	__u64 data_src;		/* Refer PERF_SAMPLE_DATA_SRC in <linux/perf_event.h> */
+	__u64 phys_addr;	/* Refer PERF_SAMPLE_PHYS_ADDR in <linux/perf_event.h> */
+	__u64 data_page_size;	/* Refer PERF_SAMPLE_DATA_PAGE_SIZE in <linux/perf_event.h> */
+	__u64 code_page_size;	/* Refer PERF_SAMPLE_CODE_PAGE_SIZE in <linux/perf_event.h> */
+	__u64 cgroup;		/* Refer PERF_SAMPLE_CGROUP in <linux/perf_event.h> */
+	__u8  cpumode;		/* Refer CPUMODE_MASK etc in <linux/perf_event.h> */
+	__u8  addr_correlates_sym; /* True => resolve_addr() can be called */
+	__u16 misc;		/* Refer perf_event_header in <linux/perf_event.h> */
+	__u32 raw_size;		/* Refer PERF_SAMPLE_RAW in <linux/perf_event.h> */
+	const void *raw_data;	/* Refer PERF_SAMPLE_RAW in <linux/perf_event.h> */
+	__u64 brstack_nr;	/* Number of brstack entries */
+	const struct perf_branch_entry *brstack; /* Refer <linux/perf_event.h> */
+	__u64 raw_callchain_nr;	/* Number of raw_callchain entries */
+	const __u64 *raw_callchain; /* Refer <linux/perf_event.h> */
+	const char *event;
+};
+
+/*
+ * Address location (as per perf script)
+ */
+struct perf_dlfilter_al {
+	__u32 size; /* Size of this structure (for compatibility checking) */
+	__u32 symoff;
+	const char *sym;
+	__u64 addr; /* Mapped address (from dso) */
+	__u64 sym_start;
+	__u64 sym_end;
+	const char *dso;
+	__u8  sym_binding; /* STB_LOCAL, STB_GLOBAL or STB_WEAK, refer <elf.h> */
+	__u8  is_64_bit; /* Only valid if dso is not NULL */
+	__u8  is_kernel_ip; /* True if in kernel space */
+	__u32 buildid_size;
+	__u8 *buildid;
+	/* Below members are only populated by resolve_ip() */
+	__u8 filtered; /* True if this sample event will be filtered out */
+	const char *comm;
+};
+
+struct perf_dlfilter_fns {
+	/* Return information about ip */
+	const struct perf_dlfilter_al *(*resolve_ip)(void *ctx);
+	/* Return information about addr (if addr_correlates_sym) */
+	const struct perf_dlfilter_al *(*resolve_addr)(void *ctx);
+	/* Return arguments from --dlarg option */
+	char **(*args)(void *ctx, int *dlargc);
+	/*
+	 * Return information about address (al->size must be set before
+	 * calling). Returns 0 on success, -1 otherwise.
+	 */
+	__s32 (*resolve_address)(void *ctx, __u64 address, struct perf_dlfilter_al *al);
+	/* Return instruction bytes and length */
+	const __u8 *(*insn)(void *ctx, __u32 *length);
+	/* Return source file name and line number */
+	const char *(*srcline)(void *ctx, __u32 *line_number);
+	/* Return perf_event_attr, refer <linux/perf_event.h> */
+	struct perf_event_attr *(*attr)(void *ctx);
+	/* Read object code, return numbers of bytes read */
+	__s32 (*object_code)(void *ctx, __u64 ip, void *buf, __u32 len);
+	/* Reserved */
+	void *(*reserved[120])(void *);
+};
+
+/*
+ * If implemented, 'start' will be called at the beginning,
+ * before any calls to 'filter_event'. Return 0 to indicate success,
+ * or return a negative error code. '*data' can be assigned for use
+ * by other functions. 'ctx' is needed for calls to perf_dlfilter_fns,
+ * but most perf_dlfilter_fns are not valid when called from 'start'.
+ */
+int start(void **data, void *ctx);
+
+/*
+ * If implemented, 'stop' will be called at the end,
+ * after any calls to 'filter_event'. Return 0 to indicate success, or
+ * return a negative error code. 'data' is set by start(). 'ctx' is
+ * needed for calls to perf_dlfilter_fns, but most perf_dlfilter_fns
+ * are not valid when called from 'stop'.
+ */
+int stop(void *data, void *ctx);
+
+/*
+ * If implemented, 'filter_event' will be called for each sample
+ * event. Return 0 to keep the sample event, 1 to filter it out, or
+ * return a negative error code. 'data' is set by start(). 'ctx' is
+ * needed for calls to perf_dlfilter_fns.
+ */
+int filter_event(void *data, const struct perf_dlfilter_sample *sample, void *ctx);
+
+/*
+ * The same as 'filter_event' except it is called before internal
+ * filtering.
+ */
+int filter_event_early(void *data, const struct perf_dlfilter_sample *sample, void *ctx);
+
+/*
+ * If implemented, return a one-line description of the filter, and optionally
+ * a longer description.
+ */
+const char *filter_description(const char **long_description);
+
+#endif


### PR DESCRIPTION
This addresses #32. Since 5.14, perf supports passing `--dlfilter file.so`. This PR creates a filter which skips over any Intel PT events which are branches within the same function. This filter is implemented in `perf_dlfilter.c` and built into `perf_dlfilter.so` by dune and using ocaml-crunch compiled into the ocaml executable for use.

Some things to note:
* There is a custom dune rule which builds the shared object. `ocaml-crunch` was added as a dependency and now to build, `gcc` is also required.
* magic-trace will detect support in `perf_capabilities.ml` for `--dlfilter` by checking the perf version. This ensures compatibility with older perf versions.
* `perf_dlfilter.h` is the include header from perf which is required. It's possible to use the system version, but placing it in magic-trace will ensure one can build even if that include is not present.

How much faster is magic-trace using the dlfilter? When running on a demo program, on a 19.194 MB perf.data file, running `perf script` goes from 1.980s with 1308709 lines to 0.534s with 358954 lines. On a 180.123 MB perf.data file, it goes from 110.279s with 75715521 lines to 53.746s with 20747507 lines. This does not include magic-trace's decoding time, but this should scale linearly with the number of lines. 

A future feature however could be to use this dlfilter to also pass information to ocaml without having to parse text using regex. However this feature alone is still a significant improvement for now.