### PR TITLE
Added env var to forcibly disable perf dlfilter

### DIFF
--- a/src/env_vars.ml
+++ b/src/env_vars.ml
@@ -16,3 +16,9 @@ let perf_is_privileged = Option.is_some (Unix.getenv "MAGIC_TRACE_PERF_IS_PRIVIL
 
    This helps magic-trace developers debug magic-trace, it's not generally useful. *)
 let debug = Option.is_some (Unix.getenv "MAGIC_TRACE_DEBUG")
+
+(* When tracing the kernel on certain systems, perf only has root access when
+   being run with a specific set of flags. Since this does not include
+   [--dlfilter], this environment variable allows the user to forcibly disable
+   filtering. *)
+let no_dlfilter = Option.is_some (Unix.getenv "MAGIC_TRACE_NO_DLFILTER")

--- a/src/env_vars.mli
+++ b/src/env_vars.mli
@@ -3,3 +3,4 @@ open! Core
 val debug : bool
 val perf_is_privileged : bool
 val perfetto_dir : string option
+val no_dlfilter : bool


### PR DESCRIPTION
Tudor pointed out the necessity of an environment variable to disable using `--dlfilter` with `perf script`. This is because on our systems, perf is only allowed to run as root and trace the kernel with certain flags which do not include `--dlfilter`. This environment variable will allow the user to forcibly disable `--dlfilter` to be able to still trace the kernel in these situations.