### PR TITLE
Add wiki page link for `-sampling` flag and wiki information on sampling backend

### DIFF
--- a/core/collection_mode.ml
+++ b/core/collection_mode.ml
@@ -23,6 +23,6 @@ let param =
       no_arg
       ~doc:
         "Use stacktrace sampling instead of Intel PT. If Intel PT is not available, \
-         magic-trace will default to this."
+         magic-trace will default to this. For more info: https://magic-trace.org/w/b"
     |> map ~f:(fun use_sampling -> select_collection_mode ~use_sampling))
 ;;


### PR DESCRIPTION
This PR should be merged after #228 since I referenced that wiki page. And the wiki (and domain) should be updated when this is merged.

The only code change is a reference to a wiki page within the `-sampling` flag help message. However the new wiki page draft this is intended to link to can be seen [here](https://github.com/Lamoreauxaj/magic-trace/wiki/Sampling-backend). Additionally I updated the [timer resolution page](https://github.com/Lamoreauxaj/magic-trace/wiki/Timer-resolution-configuration) to describe changes to configuration.