### PR TITLE
Disable dlfilter when printing trace to sexp

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -43,6 +43,9 @@ module type S = sig
 
   val decode_events
     :  ?perf_maps:Perf_map.Table.t
+    -> ?filter_same_symbol_jumps:bool
+         (** Whether to filter unnecessary events which are jumps within the same
+             function. Default [true]. *)
     -> debug_print_perf_commands:bool
     -> recording_data:Recording.Data.t option
          (** This parameter is passed to allow [decode_events] to depend

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -395,6 +395,7 @@ end
 
 let decode_events
     ?perf_maps
+    ?(filter_same_symbol_jumps = true)
     ~debug_print_perf_commands
     ~(recording_data : Recording.Data.t option)
     ~record_dir
@@ -406,7 +407,7 @@ let decode_events
     match
       ( Perf_capabilities.(do_intersect capabilities dlfilter)
       , collection_mode
-      , Env_vars.no_dlfilter )
+      , Env_vars.no_dlfilter || not filter_same_symbol_jumps )
     with
     | true, Intel_processor_trace, false ->
       let filename = record_dir ^/ "perf_dlfilter.so" in

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -221,9 +221,10 @@ module Make_commands (Backend : Backend_intf.S) = struct
       with
       | Sys_error _ -> None
     in
-    let decode_events () =
+    let decode_events ?filter_same_symbol_jumps () =
       Backend.decode_events
         ?perf_maps
+        ?filter_same_symbol_jumps
         decode_opts
         ~debug_print_perf_commands
         ~recording_data
@@ -235,7 +236,9 @@ module Make_commands (Backend : Backend_intf.S) = struct
       ~f_sexp:(fun writer ->
         let open Deferred.Or_error.Let_syntax in
         let%bind events, close_result =
-          get_events_and_close_result ~decode_events ~range_symbols
+          get_events_and_close_result
+            ~decode_events:(decode_events ~filter_same_symbol_jumps:false)
+            ~range_symbols
         in
         let%bind () = write_event_sexps writer events close_result in
         return ())


### PR DESCRIPTION
This was requested to still allow tools to consume magic-trace output without dlfiltering. Thus when writing events to a sexp file, magic-trace will disable dlfiltering such that all events are outputted. If writing to a fuschia trace file, dlfilter will still be enabled if possible since the events filtered are not useful in the ui.