### PR TITLE
.ocamlformat: 0.21 -> 0.24.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.opam
-          key: ${{ matrix.os }}-opam-${{ matrix.ocaml-version }}-flambda-musl-v3
+          key: ${{ matrix.os }}-opam-${{ matrix.ocaml-version }}-flambda-musl-v4
 
       - name: Install musl-compatible kernel headers
         run: |

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version=0.21.0
+version=0.24.1
 profile=janestreet

--- a/core/collection_mode.ml
+++ b/core/collection_mode.ml
@@ -62,11 +62,11 @@ let select_collection_mode ~extra_events ~use_sampling =
   | true -> Stacktrace_sampling { extra_events }
   | false ->
     (match Core_unix.access "/sys/bus/event_source/devices/intel_pt" [ `Exists ] with
-    | Ok () -> Intel_processor_trace { extra_events }
-    | Error _ ->
-      Core.eprintf
-        "Intel PT support not found. magic-trace will continue and use sampling instead.\n";
-      Stacktrace_sampling { extra_events })
+     | Ok () -> Intel_processor_trace { extra_events }
+     | Error _ ->
+       Core.eprintf
+         "Intel PT support not found. magic-trace will continue and use sampling instead.\n";
+       Stacktrace_sampling { extra_events })
 ;;
 
 let param =

--- a/core/event.ml
+++ b/core/event.ml
@@ -67,7 +67,7 @@ end
 module Decode_error = struct
   type t =
     { thread : Thread.t
-          (* The time is only present sometimes. I haven't figured out when, exactly, but my
+        (* The time is only present sometimes. I haven't figured out when, exactly, but my
        Skylake test machine has it while my Tiger Lake test machine doesn't. It could
        easily be a difference between different versions of perf... *)
     ; time : Time_ns_unix.Span.Option.t
@@ -95,8 +95,8 @@ let change_time (t : t) ~f : t =
   | Ok ({ time; _ } as t) -> Ok { t with time = f time }
   | Error ({ time; _ } as u) ->
     (match%optional.Time_ns_unix.Span.Option time with
-    | None -> t
-    | Some time -> Error { u with time = Time_ns_unix.Span.Option.some (f time) })
+     | None -> t
+     | Some time -> Error { u with time = Time_ns_unix.Span.Option.some (f time) })
 ;;
 
 module With_write_info = struct

--- a/core/ocaml_exception_info.ml
+++ b/core/ocaml_exception_info.ml
@@ -23,7 +23,7 @@ let create ~pushtraps ~poptraps ~entertraps : t =
     |> Array.concat
   in
   Array.sort pushtrap_and_poptrap_addresses ~compare:(fun (addr, _) (addr', _) ->
-      Int64.compare addr addr');
+    Int64.compare addr addr');
   { pushtrap_and_poptrap_addresses; entertrap_addresses = Int64.Set.of_array entertraps }
 ;;
 

--- a/core/perf_map.ml
+++ b/core/perf_map.ml
@@ -157,21 +157,21 @@ let%expect_test "pid_of_filename success" =
 
 let%expect_test "pid_of_filename failure 1" =
   Expect_test_helpers_core.require_does_raise [%here] (fun () ->
-      print_s [%message "" ~pid:(pid_of_filename "/tmp/per-512.map" : Pid.t)]);
+    print_s [%message "" ~pid:(pid_of_filename "/tmp/per-512.map" : Pid.t)]);
   [%expect {| "Perf map filename did not match default format [perf-%{pid}.map]" |}]
   |> Deferred.return
 ;;
 
 let%expect_test "pid_of_filename failure 2" =
   Expect_test_helpers_core.require_does_raise [%here] (fun () ->
-      print_s [%message "" ~pid:(pid_of_filename "/tmp/perf-512" : Pid.t)]);
+    print_s [%message "" ~pid:(pid_of_filename "/tmp/perf-512" : Pid.t)]);
   [%expect {| "Perf map filename did not match default format [perf-%{pid}.map]" |}]
   |> Deferred.return
 ;;
 
 let map_of_sequence_prefer_later sequence =
   Sequence.fold sequence ~init:Int64.Map.empty ~f:(fun map (key, data) ->
-      Map.set map ~key ~data)
+    Map.set map ~key ~data)
 ;;
 
 let load file_location =
@@ -207,20 +207,20 @@ module Table = struct
 
   let create maps =
     List.filter_map maps ~f:(function
-        | _, None -> None
-        | pid, Some map -> Some (pid, map))
+      | _, None -> None
+      | pid, Some map -> Some (pid, map))
     |> Hashtbl.of_alist_exn (module Pid)
   ;;
 
   let load_by_files files =
     Deferred.List.map files ~f:(fun filename ->
-        load filename |> Deferred.map ~f:(fun map -> pid_of_filename filename, map))
+      load filename |> Deferred.map ~f:(fun map -> pid_of_filename filename, map))
     >>| create
   ;;
 
   let load_by_pids pids =
     Deferred.List.map pids ~f:(fun pid ->
-        load (default_filename ~pid) |> Deferred.map ~f:(fun map -> pid, map))
+      load (default_filename ~pid) |> Deferred.map ~f:(fun map -> pid, map))
     >>| create
   ;;
 

--- a/core/symbol_selection.ml
+++ b/core/symbol_selection.ml
@@ -63,11 +63,11 @@ let evaluate ~supports_fzf ~elf ~header symbol_selection =
   | Use_fzf_to_select_one select ->
     let%bind chosen_name, chosen_symbol = select_owee_symbol ~elf ~header select in
     (match Owee_elf.Symbol_table.Symbol.type_attribute chosen_symbol with
-    | File ->
-      let%bind chosen_name =
-        select_within_file ~elf ~header:(header ^ " line") chosen_symbol
-      in
-      return chosen_name
-    | _ -> return chosen_name)
+     | File ->
+       let%bind chosen_name =
+         select_within_file ~elf ~header:(header ^ " line") chosen_symbol
+       in
+       return chosen_name
+     | _ -> return chosen_name)
   | User_selected user_selection -> return user_selection
 ;;

--- a/core/trace_filter.ml
+++ b/core/trace_filter.ml
@@ -10,12 +10,12 @@ module Unevaluated = struct
   (* Accepts '(foo bar)', returns { start_symbol = User_selected "foo"; stop_symbol = User_selected = "bar" } *)
   let arg_type =
     Command.Param.Arg_type.create (fun s ->
-        let start_symbol, stop_symbol =
-          Sexp.of_string s
-          |> Tuple2.t_of_sexp String.t_of_sexp String.t_of_sexp
-          |> Tuple2.map ~f:Symbol_selection.of_command_string
-        in
-        { start_symbol; stop_symbol })
+      let start_symbol, stop_symbol =
+        Sexp.of_string s
+        |> Tuple2.t_of_sexp String.t_of_sexp String.t_of_sexp
+        |> Tuple2.map ~f:Symbol_selection.of_command_string
+      in
+      { start_symbol; stop_symbol })
   ;;
 end
 

--- a/core/trace_scope.ml
+++ b/core/trace_scope.ml
@@ -20,5 +20,5 @@ let param =
   Command.Param.choose_one
     ~if_nothing_chosen:(Default_to Userspace)
     (List.map commands_and_docs ~f:(fun (variant, flag, doc) ->
-         Command.Param.flag flag (Command.Param.no_arg_some variant) ~doc))
+       Command.Param.flag flag (Command.Param.no_arg_some variant) ~doc))
 ;;

--- a/core/util.ml
+++ b/core/util.ml
@@ -1,10 +1,10 @@
 open! Core
 
 let intable_of_hex_string
-    (type a)
-    (module M : Int_intf.S with type t = a)
-    ?(remove_hex_prefix = false)
-    str
+  (type a)
+  (module M : Int_intf.S with type t = a)
+  ?(remove_hex_prefix = false)
+  str
   =
   (* Bit hacks for fast parsing of hex strings.
    *

--- a/core/when_to_snapshot.ml
+++ b/core/when_to_snapshot.ml
@@ -30,7 +30,7 @@ let param =
        (*) If you pass multiple PIDs when tracing, the trigger will only be able to \
        select a function from the first PID passed.\n\n"
   |> map ~f:(function
-         | None -> Magic_trace_or_the_application_terminates
-         | Some input ->
-           Application_calls_a_function (Symbol_selection.of_command_string input))
+       | None -> Magic_trace_or_the_application_terminates
+       | Some input ->
+         Application_calls_a_function (Symbol_selection.of_command_string input))
 ;;

--- a/direct_backend/decoding.ml
+++ b/direct_backend/decoding.ml
@@ -117,10 +117,10 @@ let handle_add_section (state : state) (add : Stub.Add_section.t) =
     | Some elf -> Some elf
     | None ->
       (match Elf.create add.filename with
-      | None -> None
-      | Some elf ->
-        Hashtbl.add_exn state.elfs_by_filename ~key:add.filename ~data:elf;
-        Some elf)
+       | None -> None
+       | Some elf ->
+         Hashtbl.add_exn state.elfs_by_filename ~key:add.filename ~data:elf;
+         Some elf)
   in
   match elf with
   | None -> ()
@@ -141,7 +141,7 @@ let convert_trace_event state (event : Stub.Event.t) =
       | None ->
         (* Tracing start/stop events don't have an isid so we need a fallback *)
         List.find state.fallback_resolvers ~f:(fun (vaddr, size, _) ->
-            event.addr > vaddr && event.addr < vaddr + size)
+          event.addr > vaddr && event.addr < vaddr + size)
         |> Option.map ~f:(fun (_, _, r) -> r)
     in
     match resolver with

--- a/direct_backend/manual_perf.ml
+++ b/direct_backend/manual_perf.ml
@@ -88,29 +88,29 @@ let read_current_maps pid =
   Owee_linux_maps.scan_pid (Pid.to_int pid)
   |> List.filter_map
        ~f:(fun { address_start; address_end; pathname; offset; perm_execute; _ } ->
-         match perm_execute with
-         | false -> None
-         | true ->
-           let open Int64 in
-           Some
-             { Mmap.vaddr = to_int_exn address_start
-             ; length = address_end - address_start |> to_int_exn
-             ; offset = to_int_exn offset
-             ; filename = pathname
-             })
+       match perm_execute with
+       | false -> None
+       | true ->
+         let open Int64 in
+         Some
+           { Mmap.vaddr = to_int_exn address_start
+           ; length = address_end - address_start |> to_int_exn
+           ; offset = to_int_exn offset
+           ; filename = pathname
+           })
 ;;
 
 module Tracing_state = struct
   type t = Stub.c_tracing_state
 
   let attach
-      ?(data_size = 0x400000)
-      ?(aux_size = 0x400000)
-      ?filter
-      ~pt_file
-      ~sideband_file
-      ~setup_file
-      pid
+    ?(data_size = 0x400000)
+    ?(aux_size = 0x400000)
+    ?filter
+    ~pt_file
+    ~sideband_file
+    ~setup_file
+    pid
     =
     let state = Stub.create_empty_state () in
     let trace_meta : Stub.Trace_meta.t =

--- a/src/for_range.ml
+++ b/src/for_range.ml
@@ -22,31 +22,31 @@ let range_hit_times ~decode_events ~range_symbols =
   let open Deferred.Or_error.Let_syntax in
   let%bind { Decode_result.events; _ } = decode_events () in
   Deferred.List.map events ~f:(fun events ->
-      let { Trace_filter.start_symbol; stop_symbol } = range_symbols in
-      let is_start symbol = String.(Symbol.display_name symbol = start_symbol) in
-      let is_stop symbol = String.(Symbol.display_name symbol = stop_symbol) in
-      Pipe.filter_map events ~f:(function
-          | Error _ | Ok { data = Power _; _ } | Ok { data = Event_sample _; _ } -> None
-          | Ok { data = Trace trace; time; _ } ->
-            (match trace.kind with
-            | Some Call ->
-              let symbol = trace.dst.symbol in
-              if is_start symbol
-              then Some { Symbol_hit.kind = Start; symbol; time }
-              else if is_stop symbol
-              then Some { Symbol_hit.kind = Stop; symbol; time }
-              else None
-            | _ -> None)
-          | Ok { data = Stacktrace_sample { callstack }; time; _ } ->
-            List.rev callstack
-            |> List.fold ~init:None ~f:(fun acc call ->
-                   match acc, call with
-                   | None, { symbol; _ } when is_start symbol ->
-                     Some { Symbol_hit.kind = Start; symbol; time }
-                   | None, { symbol; _ } when is_stop symbol ->
-                     Some { Symbol_hit.kind = Stop; symbol; time }
-                   | acc, _ -> acc))
-      |> Pipe.to_list)
+    let { Trace_filter.start_symbol; stop_symbol } = range_symbols in
+    let is_start symbol = String.(Symbol.display_name symbol = start_symbol) in
+    let is_stop symbol = String.(Symbol.display_name symbol = stop_symbol) in
+    Pipe.filter_map events ~f:(function
+      | Error _ | Ok { data = Power _; _ } | Ok { data = Event_sample _; _ } -> None
+      | Ok { data = Trace trace; time; _ } ->
+        (match trace.kind with
+         | Some Call ->
+           let symbol = trace.dst.symbol in
+           if is_start symbol
+           then Some { Symbol_hit.kind = Start; symbol; time }
+           else if is_stop symbol
+           then Some { Symbol_hit.kind = Stop; symbol; time }
+           else None
+         | _ -> None)
+      | Ok { data = Stacktrace_sample { callstack }; time; _ } ->
+        List.rev callstack
+        |> List.fold ~init:None ~f:(fun acc call ->
+             match acc, call with
+             | None, { symbol; _ } when is_start symbol ->
+               Some { Symbol_hit.kind = Start; symbol; time }
+             | None, { symbol; _ } when is_stop symbol ->
+               Some { Symbol_hit.kind = Stop; symbol; time }
+             | acc, _ -> acc))
+    |> Pipe.to_list)
   |> Deferred.map ~f:Or_error.return
 ;;
 
@@ -58,9 +58,9 @@ let remove_unmatched_hits (hits : Symbol_hit.t list) =
     | [ { Symbol_hit.kind = Stop; _ } ] -> accum
     | first :: second :: rest ->
       (match first.kind, second.kind with
-      | _, Start -> remove_unmatched_hits' ~accum (second :: rest)
-      | Stop, Stop -> remove_unmatched_hits' ~accum rest
-      | Start, Stop -> remove_unmatched_hits' ~accum:(second :: first :: accum) rest)
+       | _, Start -> remove_unmatched_hits' ~accum (second :: rest)
+       | Stop, Stop -> remove_unmatched_hits' ~accum rest
+       | Start, Stop -> remove_unmatched_hits' ~accum:(second :: first :: accum) rest)
   in
   remove_unmatched_hits' ~accum:[] hits |> List.rev
 ;;
@@ -76,29 +76,28 @@ let decode_events_and_annotate ~decode_events ~range_symbols =
   let events =
     List.zip_exn events hit_sequences
     |> List.map ~f:(fun (events, hit_sequence) ->
-           Pipe.folding_map
-             events
-             ~init:(hit_sequence, false)
-             ~f:(fun (hits, in_filtered_region) event ->
-               let hits, in_filtered_region =
-                 match hits with
-                 | [] -> hits, in_filtered_region
-                 | hd :: tl ->
-                   (match event with
-                   | Ok { data = Trace { kind = Some Call; dst; _ }; time; _ }
-                     when Time_ns_unix.Span.(time = hd.time)
-                          && Symbol.equal dst.symbol hd.symbol ->
-                     tl, not in_filtered_region
-                   | Ok { data = Stacktrace_sample _; time; _ }
-                     when Time_ns_unix.Span.(time = hd.time) -> tl, not in_filtered_region
-                   | Ok { data = Trace _; _ }
-                   | Ok { data = Power _; _ }
-                   | Ok { data = Stacktrace_sample _; _ }
-                   | Ok { data = Event_sample _; _ }
-                   | Error _ -> hits, in_filtered_region)
-               in
-               ( (hits, in_filtered_region)
-               , Event.With_write_info.create ~should_write:in_filtered_region event )))
+         Pipe.folding_map
+           events
+           ~init:(hit_sequence, false)
+           ~f:(fun (hits, in_filtered_region) event ->
+           let hits, in_filtered_region =
+             match hits with
+             | [] -> hits, in_filtered_region
+             | hd :: tl ->
+               (match event with
+                | Ok { data = Trace { kind = Some Call; dst; _ }; time; _ }
+                  when Time_ns_unix.Span.(time = hd.time)
+                       && Symbol.equal dst.symbol hd.symbol -> tl, not in_filtered_region
+                | Ok { data = Stacktrace_sample _; time; _ }
+                  when Time_ns_unix.Span.(time = hd.time) -> tl, not in_filtered_region
+                | Ok { data = Trace _; _ }
+                | Ok { data = Power _; _ }
+                | Ok { data = Stacktrace_sample _; _ }
+                | Ok { data = Event_sample _; _ }
+                | Error _ -> hits, in_filtered_region)
+           in
+           ( (hits, in_filtered_region)
+           , Event.With_write_info.create ~should_write:in_filtered_region event )))
   in
   return (events, close_result)
 ;;

--- a/src/perf_capabilities.ml
+++ b/src/perf_capabilities.ml
@@ -36,7 +36,7 @@ module Version = struct
   let of_perf_version_string_exn version_string =
     try
       Scanf.sscanf version_string "perf version %d.%d" (fun major minor ->
-          { major; minor })
+        { major; minor })
     with
     | Scanf.Scan_failure _ | End_of_file ->
       raise_s
@@ -64,12 +64,12 @@ let supports_last_branch_record () =
   let flag_re = Re.Perl.re {|^flags\s*:\s+(\S.*)$|} |> Re.compile in
   let flags =
     List.filter_map cpuinfo ~f:(fun line ->
-        try
-          match Re.Group.all (Re.exec flag_re line) with
-          | [| _; flags |] -> Some (String.split ~on:' ' flags)
-          | _ -> None
-        with
-        | _ -> None)
+      try
+        match Re.Group.all (Re.exec flag_re line) with
+        | [| _; flags |] -> Some (String.split ~on:' ' flags)
+        | _ -> None
+      with
+      | _ -> None)
   in
   (* Check if pdcm in intersection of all processor flags *)
   let contains_pdcm flags = List.exists flags ~f:(fun flag -> String.(flag = "pdcm")) in

--- a/src/process_info.ml
+++ b/src/process_info.ml
@@ -23,8 +23,8 @@ let read_proc_info pid =
 let read_all_proc_info () =
   Sys_unix.readdir "/proc"
   |> Array.iter ~f:(fun filename ->
-         try Pid.of_string filename |> read_proc_info with
-         | _ -> ())
+       try Pid.of_string filename |> read_proc_info with
+       | _ -> ())
 ;;
 
 let cmdline_of_pid pid = Hashtbl.find state pid

--- a/src/ptrace.ml
+++ b/src/ptrace.ml
@@ -16,16 +16,16 @@ let fork_exec_stopped ~prog ~argv () =
     if not (ptrace_traceme ()) then sys_exit 126;
     never_returns
       (try Core_unix.exec ~prog ~argv () with
-      | _ -> sys_exit 127)
+       | _ -> sys_exit 127)
   | `In_the_parent pid ->
     (match Core_unix.wait_untraced (`Pid pid) with
-    | _, Error (`Stop _) -> pid
-    | _, result ->
-      raise_s
-        [%message
-          "expected child to stop but it did not"
-            (pid : Pid.t)
-            (result : (unit, Core_unix.Exit_or_signal_or_stop.error) Result.t)])
+     | _, Error (`Stop _) -> pid
+     | _, result ->
+       raise_s
+         [%message
+           "expected child to stop but it did not"
+             (pid : Pid.t)
+             (result : (unit, Core_unix.Exit_or_signal_or_stop.error) Result.t)])
 ;;
 
 external resume : Pid.t -> unit = "magic_ptrace_detach"

--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -80,8 +80,7 @@ module Callstack = struct
     in
     let ans =
       List.take_while zipped_stacks ~f:(fun (current_location, future_location) ->
-          Int64.(
-            current_location.instruction_pointer = future_location.instruction_pointer))
+        Int64.(current_location.instruction_pointer = future_location.instruction_pointer))
       |> List.length
     in
     ans
@@ -109,7 +108,7 @@ module Thread_info = struct
     ; mutable pending_events : Pending_event.t list
     ; mutable pending_time : Mapped_time.t
     ; start_events : (Mapped_time.t * Pending_event.t) Deque.t
-          (* When the last event arrived. Used to give timestamps to events lacking them. *)
+        (* When the last event arrived. Used to give timestamps to events lacking them. *)
     ; mutable last_event_time : Mapped_time.t
     ; track_group_id : int
     ; extra_event_tracks : ('thread[@sexp.opaque]) Hashtbl.M(Collection_mode.Event.Name).t
@@ -158,13 +157,13 @@ let allocate_thread (type thread) (t : thread inner) ~pid ~name : thread =
 ;;
 
 let write_duration_begin
-    (type thread)
-    (t : thread inner)
-    ~args
-    ~thread
-    ~name
-    ~(time : Mapped_time.t)
-    : unit
+  (type thread)
+  (t : thread inner)
+  ~args
+  ~thread
+  ~name
+  ~(time : Mapped_time.t)
+  : unit
   =
   let module T = (val t.trace) in
   if t.in_filtered_region
@@ -172,13 +171,13 @@ let write_duration_begin
 ;;
 
 let write_duration_end
-    (type thread)
-    (t : thread inner)
-    ~args
-    ~thread
-    ~name
-    ~(time : Mapped_time.t)
-    : unit
+  (type thread)
+  (t : thread inner)
+  ~args
+  ~thread
+  ~name
+  ~(time : Mapped_time.t)
+  : unit
   =
   let module T = (val t.trace) in
   if t.in_filtered_region
@@ -186,14 +185,14 @@ let write_duration_end
 ;;
 
 let write_duration_complete
-    (type thread)
-    (t : thread inner)
-    ~args
-    ~thread
-    ~name
-    ~(time : Mapped_time.t)
-    ~(time_end : Mapped_time.t)
-    : unit
+  (type thread)
+  (t : thread inner)
+  ~args
+  ~thread
+  ~name
+  ~(time : Mapped_time.t)
+  ~(time_end : Mapped_time.t)
+  : unit
   =
   let module T = (val t.trace) in
   if t.in_filtered_region
@@ -207,13 +206,13 @@ let write_duration_complete
 ;;
 
 let write_duration_instant
-    (type thread)
-    (t : thread inner)
-    ~args
-    ~thread
-    ~name
-    ~(time : Mapped_time.t)
-    : unit
+  (type thread)
+  (t : thread inner)
+  ~args
+  ~thread
+  ~name
+  ~(time : Mapped_time.t)
+  : unit
   =
   let module T = (val t.trace) in
   if t.in_filtered_region
@@ -221,13 +220,13 @@ let write_duration_instant
 ;;
 
 let write_counter
-    (type thread)
-    (t : thread inner)
-    ~args
-    ~thread
-    ~name
-    ~(time : Mapped_time.t)
-    : unit
+  (type thread)
+  (t : thread inner)
+  ~args
+  ~thread
+  ~name
+  ~(time : Mapped_time.t)
+  : unit
   =
   let module T = (val t.trace) in
   if t.in_filtered_region
@@ -242,58 +241,58 @@ let write_hits (T t) hits =
     let pid = allocate_pid t ~name:"Snapshot symbol hits" in
     let thread = allocate_thread t ~pid ~name:"hits" in
     List.iter hits ~f:(fun (sym, (hit : Breakpoint.Hit.t)) ->
-        let is_default_symbol = String.( = ) sym Magic_trace.Private.stop_symbol in
-        let name = [%string "hit %{sym}"] in
-        let time = map_time t hit.timestamp in
-        let args =
-          Tracing.Trace.Arg.
-            [ "timestamp", Int (Time_ns.Span.to_int_ns hit.timestamp)
-            ; "tid", Int (Pid.to_int hit.tid)
-            ; "ip", Pointer hit.ip
-            ]
-        in
-        (* Args that are computed from captured registers are only meaningful on our
+      let is_default_symbol = String.( = ) sym Magic_trace.Private.stop_symbol in
+      let name = [%string "hit %{sym}"] in
+      let time = map_time t hit.timestamp in
+      let args =
+        Tracing.Trace.Arg.
+          [ "timestamp", Int (Time_ns.Span.to_int_ns hit.timestamp)
+          ; "tid", Int (Pid.to_int hit.tid)
+          ; "ip", Pointer hit.ip
+          ]
+      in
+      (* Args that are computed from captured registers are only meaningful on our
            special stop symbol, we still capture them regardless, but on other symbols
            they'll just have confusing broken values. *)
-        let args =
-          if is_default_symbol
-          then
-            Tracing.Trace.Arg.
-              [ "timestamp_passed", Int (Time_ns.Span.to_int_ns hit.passed_timestamp)
-              ; "arg", Int hit.passed_val
-              ]
-            @ args
-          else args
-        in
-        (* For the special symbol, if present the passed timestamp comes from
+      let args =
+        if is_default_symbol
+        then
+          Tracing.Trace.Arg.
+            [ "timestamp_passed", Int (Time_ns.Span.to_int_ns hit.passed_timestamp)
+            ; "arg", Int hit.passed_val
+            ]
+          @ args
+        else args
+      in
+      (* For the special symbol, if present the passed timestamp comes from
            Magic_trace.mark_start and marks the start of a region of interest.
 
            We check it for validity since it's possible someone uses an older version of
            [Magic_trace.take_snapshot] and that should at least produce a valid trace. *)
-        let valid_timestamp =
-          Time_ns.Span.(
-            hit.passed_timestamp > t.base_time && hit.passed_timestamp < hit.timestamp)
-        in
-        let start =
-          if is_default_symbol && valid_timestamp
-          then map_time t hit.passed_timestamp
-          else time
-        in
-        write_duration_complete t ~thread ~args ~name ~time:start ~time_end:time))
+      let valid_timestamp =
+        Time_ns.Span.(
+          hit.passed_timestamp > t.base_time && hit.passed_timestamp < hit.timestamp)
+      in
+      let start =
+        if is_default_symbol && valid_timestamp
+        then map_time t hit.passed_timestamp
+        else time
+      in
+      write_duration_complete t ~thread ~args ~name ~time:start ~time_end:time))
 ;;
 
 let create_expert
-    ~trace_scope
-    ~debug_info
-    ~ocaml_exception_info
-    ~earliest_time
-    ~hits
-    ~annotate_inferred_start_times
-    trace
+  ~trace_scope
+  ~debug_info
+  ~ocaml_exception_info
+  ~earliest_time
+  ~hits
+  ~annotate_inferred_start_times
+  trace
   =
   let base_time =
     List.fold hits ~init:earliest_time ~f:(fun acc (_, (hit : Breakpoint.Hit.t)) ->
-        Time_ns.Span.min acc hit.timestamp)
+      Time_ns.Span.min acc hit.timestamp)
   in
   let t =
     T
@@ -312,13 +311,13 @@ let create_expert
 ;;
 
 let create
-    ~trace_scope
-    ~debug_info
-    ~ocaml_exception_info
-    ~earliest_time
-    ~hits
-    ~annotate_inferred_start_times
-    trace
+  ~trace_scope
+  ~debug_info
+  ~ocaml_exception_info
+  ~earliest_time
+  ~hits
+  ~annotate_inferred_start_times
+  trace
   =
   create_expert
     ~trace_scope
@@ -331,11 +330,11 @@ let create
 ;;
 
 let write_pending_event'
-    (type thread)
-    (t : thread inner)
-    (thread : thread Thread_info.t)
-    time
-    { Pending_event.symbol; kind }
+  (type thread)
+  (t : thread inner)
+  (thread : thread Thread_info.t)
+  time
+  { Pending_event.symbol; kind }
   =
   let display_name = Symbol.display_name symbol in
   match kind with
@@ -364,17 +363,17 @@ let write_pending_event'
         address @ [ "symbol", Interned display_name ]
       | _ ->
         (match Option.bind (Int64.to_int base_address) ~f:(Hashtbl.find t.debug_info) with
-        | None -> address @ [ "symbol", Interned display_name ]
-        | Some (info : Elf.Location.t) ->
-          address
-          @ [ "line", Int info.line
-            ; "col", Int info.col
-            ; "symbol", Interned display_name
-            ]
-          @
-          (match info.filename with
-          | Some x -> [ "file", Interned x ]
-          | None -> []))
+         | None -> address @ [ "symbol", Interned display_name ]
+         | Some (info : Elf.Location.t) ->
+           address
+           @ [ "line", Int info.line
+             ; "col", Int info.col
+             ; "symbol", Interned display_name
+             ]
+           @
+           (match info.filename with
+            | Some x -> [ "file", Interned x ]
+            | None -> []))
     in
     let inferred_start_time_arg =
       if from_untraced then [ "inferred_start_time", Interned "true" ] else []
@@ -408,10 +407,10 @@ let consumes_time { Pending_event.symbol = _; kind } =
 ;;
 
 let write_pending_event
-    (t : _ inner)
-    (thread : _ Thread_info.t)
-    time
-    (ev : Pending_event.t)
+  (t : _ inner)
+  (thread : _ Thread_info.t)
+  time
+  (ev : Pending_event.t)
   =
   match ev.kind with
   | Ret_from_untraced _ | Call { from_untraced = true; _ } ->
@@ -429,18 +428,16 @@ let flush (t : _ inner) ~to_time (thread : _ Thread_info.t) =
   let ns_offset = ref 0 in
   let shares_consumed = ref 0 in
   List.iter (List.rev thread.pending_events) ~f:(fun ev ->
-      let ns_share =
-        if consumes_time ev
-        then (
-          incr shares_consumed;
-          (total_ns - !ns_offset) / (count - !shares_consumed + 1))
-        else 0
-      in
-      let time =
-        Mapped_time.add thread.pending_time (Time_ns.Span.of_int_ns !ns_offset)
-      in
-      ns_offset := !ns_offset + ns_share;
-      write_pending_event t thread time ev);
+    let ns_share =
+      if consumes_time ev
+      then (
+        incr shares_consumed;
+        (total_ns - !ns_offset) / (count - !shares_consumed + 1))
+      else 0
+    in
+    let time = Mapped_time.add thread.pending_time (Time_ns.Span.of_int_ns !ns_offset) in
+    ns_offset := !ns_offset + ns_share;
+    write_pending_event t thread time ev);
   thread.pending_time <- to_time;
   thread.pending_events <- []
 ;;
@@ -513,10 +510,10 @@ let create_thread t event =
     | None -> default_name
     | Some pid ->
       (match Process_info.cmdline_of_pid pid with
-      | None -> default_name
-      | Some cmdline ->
-        let concat_cmdline = String.concat ~sep:" " cmdline in
-        [%string "%{concat_cmdline} %{default_name}"])
+       | None -> default_name
+       | Some cmdline ->
+         let concat_cmdline = String.concat ~sep:" " cmdline in
+         [%string "%{concat_cmdline} %{default_name}"])
   in
   let track_group_id = allocate_pid t ~name in
   let thread = allocate_thread t ~pid:track_group_id ~name:"main" in
@@ -526,10 +523,10 @@ let create_thread t event =
   ; last_decode_error_time = effective_time
   ; ocaml_exception_state =
       (match t.ocaml_exception_info with
-      | None -> Without_exception_info { frames_to_unwind = ref 0 }
-      | Some ocaml_exception_info ->
-        With_exception_info
-          { ocaml_exception_info; last_known_instruction_pointer = ref None })
+       | None -> Without_exception_info { frames_to_unwind = ref 0 }
+       | Some ocaml_exception_info ->
+         With_exception_info
+           { ocaml_exception_info; last_known_instruction_pointer = ref None })
   ; pending_events = []
   ; pending_time = Mapped_time.start_of_trace
   ; start_events = Deque.create ()
@@ -583,7 +580,7 @@ let rec clear_all_callstacks t thread_info ~time =
 let end_of_thread t (thread_info : _ Thread_info.t) ~time ~is_kernel_address : unit =
   let to_time = thread_info.pending_time in
   Deque.iter' thread_info.start_events `front_to_back ~f:(fun (time, ev) ->
-      write_pending_event' t thread_info time ev);
+    write_pending_event' t thread_info time ev);
   Deque.clear thread_info.start_events;
   clear_all_callstacks t thread_info ~time;
   flush t ~to_time thread_info;
@@ -621,7 +618,7 @@ end = struct
 
   let current_stack_contains_known_gogo_destination (thread_info : _ Thread_info.t) =
     Stack.find thread_info.callstack.stack ~f:(fun location ->
-        is_known_gogo_destination location)
+      is_known_gogo_destination location)
     |> Option.is_some
   ;;
 
@@ -665,10 +662,10 @@ let ret t (thread_info : _ Thread_info.t) ~time : unit =
 ;;
 
 let check_current_symbol
-    t
-    (thread_info : _ Thread_info.t)
-    ~time
-    (location : Event.Location.t)
+  t
+  (thread_info : _ Thread_info.t)
+  ~time
+  (location : Event.Location.t)
   =
   (* After every operation, we should be in a situation where the current symbol under
      the pc matches the symbol at the top of the callstack. This can go out-of-sync
@@ -736,16 +733,17 @@ end = struct
   let ret_track_exn_data t thread_info ~time =
     let { Thread_info.callstack; ocaml_exception_state; _ } = thread_info in
     (match ocaml_exception_state with
-    | With_exception_info _ -> ()
-    | Without_exception_info { frames_to_unwind } ->
-      (match Callstack.top callstack with
-      | Some { symbol = From_perf symbol; _ } ->
-        (match symbol with
-        | "caml_next_frame_descriptor" -> incr frames_to_unwind
-        | "caml_raise_exn" -> unwind_stack t thread_info ~time ~frames_to_unwind (-2)
-        | "caml_raise_exception" -> unwind_stack t thread_info ~time ~frames_to_unwind 1
-        | _ -> ())
-      | _ -> ()));
+     | With_exception_info _ -> ()
+     | Without_exception_info { frames_to_unwind } ->
+       (match Callstack.top callstack with
+        | Some { symbol = From_perf symbol; _ } ->
+          (match symbol with
+           | "caml_next_frame_descriptor" -> incr frames_to_unwind
+           | "caml_raise_exn" -> unwind_stack t thread_info ~time ~frames_to_unwind (-2)
+           | "caml_raise_exception" ->
+             unwind_stack t thread_info ~time ~frames_to_unwind 1
+           | _ -> ())
+        | _ -> ()));
     ret t thread_info ~time
   ;;
 
@@ -757,10 +755,10 @@ end = struct
   ;;
 
   let check_current_symbol_track_entertraps
-      t
-      (thread_info : 'a Thread_info.t)
-      ~time
-      (dst : Event.Location.t)
+    t
+    (thread_info : 'a Thread_info.t)
+    ~time
+    (dst : Event.Location.t)
     =
     match thread_info.ocaml_exception_state with
     | With_exception_info { ocaml_exception_info; _ }
@@ -771,39 +769,39 @@ end = struct
   ;;
 
   let track_executed_pushtraps_and_poptraps_in_range
-      t
-      (thread_info : _ Thread_info.t)
-      ~(src : Event.Location.t)
-      ~(dst : Event.Location.t)
-      ~time
+    t
+    (thread_info : _ Thread_info.t)
+    ~(src : Event.Location.t)
+    ~(dst : Event.Location.t)
+    ~time
     =
     match thread_info.ocaml_exception_state with
     | Without_exception_info _ -> ()
     | With_exception_info { ocaml_exception_info; last_known_instruction_pointer } ->
       (match !last_known_instruction_pointer with
-      | None -> ()
-      | Some last_known_instruction_pointer ->
-        Ocaml_exception_info.iter_pushtraps_and_poptraps_in_range
-          ocaml_exception_info
-          ~from:last_known_instruction_pointer
-          ~to_:src.instruction_pointer
-          ~f:(fun (addr, kind) ->
-            match kind with
-            | Poptrap -> clear_trap_stack t thread_info ~time
-            | Pushtrap ->
-              Stack.push thread_info.inactive_callstacks thread_info.callstack;
-              thread_info.callstack <- Callstack.create ~create_time:time;
-              if !debug
-              then
-                call
-                  t
-                  thread_info
-                  ~time
-                  ~location:
-                    { instruction_pointer = 0L
-                    ; symbol_offset = 0
-                    ; symbol = From_perf [%string "[push trap @ %{addr#Int64.Hex}]"]
-                    }));
+       | None -> ()
+       | Some last_known_instruction_pointer ->
+         Ocaml_exception_info.iter_pushtraps_and_poptraps_in_range
+           ocaml_exception_info
+           ~from:last_known_instruction_pointer
+           ~to_:src.instruction_pointer
+           ~f:(fun (addr, kind) ->
+           match kind with
+           | Poptrap -> clear_trap_stack t thread_info ~time
+           | Pushtrap ->
+             Stack.push thread_info.inactive_callstacks thread_info.callstack;
+             thread_info.callstack <- Callstack.create ~create_time:time;
+             if !debug
+             then
+               call
+                 t
+                 thread_info
+                 ~time
+                 ~location:
+                   { instruction_pointer = 0L
+                   ; symbol_offset = 0
+                   ; symbol = From_perf [%string "[push trap @ %{addr#Int64.Hex}]"]
+                   }));
       last_known_instruction_pointer := Some dst.instruction_pointer
   ;;
 end
@@ -823,29 +821,25 @@ let end_of_trace ?to_time (T t) =
   (* CR-someday cgaebel: I wish this iteration had a defined order; it'd make magic-trace
      a little bit more deterministic. *)
   Hashtbl.iter t.thread_info ~f:(fun thread_info ->
-      end_of_thread
-        t
-        thread_info
-        ~time:thread_info.last_event_time
-        ~is_kernel_address:false;
-      match to_time with
-      | Some time ->
-        let mapped_time = map_time t time in
-        thread_info.pending_time <- mapped_time;
-        thread_info.last_event_time <- mapped_time;
-        thread_info.callstack.create_time <- mapped_time
-      | None -> ())
+    end_of_thread t thread_info ~time:thread_info.last_event_time ~is_kernel_address:false;
+    match to_time with
+    | Some time ->
+      let mapped_time = map_time t time in
+      thread_info.pending_time <- mapped_time;
+      thread_info.last_event_time <- mapped_time;
+      thread_info.callstack.create_time <- mapped_time
+    | None -> ())
 ;;
 
 let rewrite_callstack t ~(callstack : Callstack.t) ~thread_info ~time =
   let called_locations = callstack.stack |> Stack.to_list |> List.rev in
   List.iter called_locations ~f:(fun location ->
-      write_pending_event'
-        t
-        thread_info
-        time
-        (Pending_event.create_call location ~from_untraced:true)
-      (* Not necessarily true, but setting [~from_untraced:true] causes the timestamp to be annotated as inferred *));
+    write_pending_event'
+      t
+      thread_info
+      time
+      (Pending_event.create_call location ~from_untraced:true)
+    (* Not necessarily true, but setting [~from_untraced:true] causes the timestamp to be annotated as inferred *));
   callstack.create_time
     <- Mapped_time.add
          time
@@ -859,7 +853,7 @@ let rewrite_all_callstacks t ~(thread_info : _ Thread_info.t) ~time =
     thread_info.inactive_callstacks |> Stack.to_list |> List.rev
   in
   List.iter inactive_callstacks ~f:(fun callstack ->
-      rewrite_callstack t ~callstack ~thread_info ~time);
+    rewrite_callstack t ~callstack ~thread_info ~time);
   rewrite_callstack t ~callstack:thread_info.callstack ~thread_info ~time
 ;;
 
@@ -867,11 +861,11 @@ let maybe_start_filtered_region t ~should_write ~time =
   if (not t.in_filtered_region) && should_write
   then (
     Hashtbl.iter t.thread_info ~f:(fun thread_info ->
-        flush t ~to_time:time thread_info;
-        Deque.clear thread_info.start_events);
+      flush t ~to_time:time thread_info;
+      Deque.clear thread_info.start_events);
     t.in_filtered_region <- true;
     Hashtbl.iter t.thread_info ~f:(fun thread_info ->
-        rewrite_all_callstacks t ~thread_info ~time))
+      rewrite_all_callstacks t ~thread_info ~time))
 ;;
 
 let maybe_stop_filtered_region t ~should_write =
@@ -909,7 +903,7 @@ let write_event (T t) event =
     let track_name = Collection_mode.Event.Name.to_string name in
     let track_thread =
       Hashtbl.find_or_add thread_info.extra_event_tracks name ~default:(fun () ->
-          allocate_thread t ~pid:thread_info.track_group_id ~name:track_name)
+        allocate_thread t ~pid:thread_info.track_group_id ~name:track_name)
     in
     let args =
       Tracing.Trace.Arg.(
@@ -970,96 +964,96 @@ let write_event (T t) event =
       ~dst
       ~time;
     (match kind, trace_state_change with
-    | Some Call, (None | Some End) -> call t thread_info ~time ~location:dst
-    | ( Some (Call | Syscall | Return | Hardware_interrupt | Iret | Sysret | Jump)
-      , Some Start )
-    | Some (Hardware_interrupt | Jump), Some End ->
-      raise_s
-        [%message
-          "BUG: magic-trace devs thought this event was impossible, but you just proved \
-           them wrong. Please report this to \
-           https://github.com/janestreet/magic-trace/issues/"
-            (event : Event.t)]
-    | None, Some End -> call t thread_info ~time ~location:Event.Location.untraced
-    | Some Syscall, Some End ->
-      (* We should only be getting these under /u *)
-      assert_trace_scope t outer_event [ Userspace ];
-      call t thread_info ~time ~location:Event.Location.syscall
-    | Some Return, Some End -> call t thread_info ~time ~location:Event.Location.returned
-    | Some Return, None ->
-      Ocaml_hacks.ret_track_exn_data t thread_info ~time;
-      check_current_symbol t thread_info ~time dst
-    | None, Some Start ->
-      (* Might get this under /u, /k, and /uk, but we need to handle them all
+     | Some Call, (None | Some End) -> call t thread_info ~time ~location:dst
+     | ( Some (Call | Syscall | Return | Hardware_interrupt | Iret | Sysret | Jump)
+       , Some Start )
+     | Some (Hardware_interrupt | Jump), Some End ->
+       raise_s
+         [%message
+           "BUG: magic-trace devs thought this event was impossible, but you just proved \
+            them wrong. Please report this to \
+            https://github.com/janestreet/magic-trace/issues/"
+             (event : Event.t)]
+     | None, Some End -> call t thread_info ~time ~location:Event.Location.untraced
+     | Some Syscall, Some End ->
+       (* We should only be getting these under /u *)
+       assert_trace_scope t outer_event [ Userspace ];
+       call t thread_info ~time ~location:Event.Location.syscall
+     | Some Return, Some End -> call t thread_info ~time ~location:Event.Location.returned
+     | Some Return, None ->
+       Ocaml_hacks.ret_track_exn_data t thread_info ~time;
+       check_current_symbol t thread_info ~time dst
+     | None, Some Start ->
+       (* Might get this under /u, /k, and /uk, but we need to handle them all
        differently. *)
-      if Trace_scope.equal t.trace_scope Kernel
-      then (
-        (* We're back in the kernel after having been in userspace. We have a
+       if Trace_scope.equal t.trace_scope Kernel
+       then (
+         (* We're back in the kernel after having been in userspace. We have a
            brand new stack to work with. [clear_callstack] here should only be
            clearing the [untraced] frame here pushed by [End (Iret | Sysret)]. *)
-        clear_callstack t thread_info ~time;
-        Thread_info.set_callstack_from_addr
-          thread_info
-          ~addr:dst.instruction_pointer
-          ~time)
-      else if Callstack.is_empty thread_info.callstack
-      then
-        (* View stopping tracing always as a call (typically the result of a call
+         clear_callstack t thread_info ~time;
+         Thread_info.set_callstack_from_addr
+           thread_info
+           ~addr:dst.instruction_pointer
+           ~time)
+       else if Callstack.is_empty thread_info.callstack
+       then
+         (* View stopping tracing always as a call (typically the result of a call
            into a special library / linker), with starting tracing again as
            exiting it. The one exception is the initial start of the trace for
            that process, when there is no stack and a prior end won't have pushed
            a synthetic stack frame. *)
-        call t thread_info ~time ~location:dst
-      else
-        (* We don't call [check_current_symbol] here because stops don't change
+         call t thread_info ~time ~location:dst
+       else
+         (* We don't call [check_current_symbol] here because stops don't change
            the program location in most cases, and when a call to a symbol page
            faults, the restart after the page fault at the new location would get
            treated as a tail call if we did call [check_current_symbol]. *)
-        Ocaml_hacks.ret_track_exn_data t thread_info ~time
-    | Some ((Syscall | Hardware_interrupt) as kind), None ->
-      (* We should only be getting [Syscall] these under /uk, but we can get
+         Ocaml_hacks.ret_track_exn_data t thread_info ~time
+     | Some ((Syscall | Hardware_interrupt) as kind), None ->
+       (* We should only be getting [Syscall] these under /uk, but we can get
          [Hardware_interrupt] under /uk, /k. *)
-      [ [ Trace_scope.Userspace_and_kernel ]
-      ; (if [%compare.equal: Event.Kind.t] kind Hardware_interrupt
-        then [ Kernel ]
-        else [])
-      ]
-      |> List.concat
-      |> assert_trace_scope t outer_event;
-      (* A syscall or hardware interrupt can be modelled as operating on a new
+       [ [ Trace_scope.Userspace_and_kernel ]
+       ; (if [%compare.equal: Event.Kind.t] kind Hardware_interrupt
+         then [ Kernel ]
+         else [])
+       ]
+       |> List.concat
+       |> assert_trace_scope t outer_event;
+       (* A syscall or hardware interrupt can be modelled as operating on a new
          stack, and shouldn't be allowed to modify the previous stack.
 
          Also, hardware interrupts can occur during syscalls, so we maintain a
          "stack of callstacks" here. *)
-      Stack.push thread_info.inactive_callstacks thread_info.callstack;
-      Thread_info.set_callstack_from_addr thread_info ~addr:dst.instruction_pointer ~time;
-      call t thread_info ~time ~location:dst
-    | Some (Iret | Sysret), Some End ->
-      (* We should only be getting these under /k *)
-      assert_trace_scope t outer_event [ Kernel ];
-      clear_callstack t thread_info ~time;
-      call t thread_info ~time ~location:Event.Location.untraced
-    | Some ((Iret | Sysret) as kind), None ->
-      (* We should only get [Sysret] under /uk, but might get [Iret] under /k as
+       Stack.push thread_info.inactive_callstacks thread_info.callstack;
+       Thread_info.set_callstack_from_addr thread_info ~addr:dst.instruction_pointer ~time;
+       call t thread_info ~time ~location:dst
+     | Some (Iret | Sysret), Some End ->
+       (* We should only be getting these under /k *)
+       assert_trace_scope t outer_event [ Kernel ];
+       clear_callstack t thread_info ~time;
+       call t thread_info ~time ~location:Event.Location.untraced
+     | Some ((Iret | Sysret) as kind), None ->
+       (* We should only get [Sysret] under /uk, but might get [Iret] under /k as
          well (because the kernel can be interrupted). *)
-      [ [ Trace_scope.Userspace_and_kernel ]
-      ; (if [%compare.equal: Event.Kind.t] kind Iret then [ Kernel ] else [])
-      ]
-      |> List.concat
-      |> assert_trace_scope t outer_event;
-      clear_callstack t thread_info ~time;
-      (match Stack.pop thread_info.inactive_callstacks with
-      | Some callstack -> thread_info.callstack <- callstack
-      | None ->
-        Thread_info.set_callstack_from_addr
-          thread_info
-          ~addr:dst.instruction_pointer
-          ~time;
-        check_current_symbol t thread_info ~time dst)
-    | Some Jump, None ->
-      Ocaml_hacks.check_current_symbol_track_entertraps t thread_info ~time dst
-    (* (None, _) comes up when perf spews something magic-trace doesn't recognize.
+       [ [ Trace_scope.Userspace_and_kernel ]
+       ; (if [%compare.equal: Event.Kind.t] kind Iret then [ Kernel ] else [])
+       ]
+       |> List.concat
+       |> assert_trace_scope t outer_event;
+       clear_callstack t thread_info ~time;
+       (match Stack.pop thread_info.inactive_callstacks with
+        | Some callstack -> thread_info.callstack <- callstack
+        | None ->
+          Thread_info.set_callstack_from_addr
+            thread_info
+            ~addr:dst.instruction_pointer
+            ~time;
+          check_current_symbol t thread_info ~time dst)
+     | Some Jump, None ->
+       Ocaml_hacks.check_current_symbol_track_entertraps t thread_info ~time dst
+     (* (None, _) comes up when perf spews something magic-trace doesn't recognize.
        Instead of crashing, ignore it and keep going. *)
-    | None, _ -> ());
+     | None, _ -> ());
     if !debug then print_s (sexp_of_inner t)
 ;;

--- a/src/tracing_tool_output.ml
+++ b/src/tracing_tool_output.ml
@@ -107,7 +107,7 @@ module Serve = struct
     in
     let stop = Cohttp_async.Server.close_finished server in
     Async_unix.Signal.handle ~stop [ Signal.int ] ~f:(fun (_ : Signal.t) ->
-        Cohttp_async.Server.close server |> don't_wait_for);
+      Cohttp_async.Server.close server |> don't_wait_for);
     Core.eprintf "Open %s to view the %s in Perfetto!\n%!" (url t) filename;
     stop |> Deferred.ok
   ;;
@@ -137,8 +137,8 @@ let param =
     | false -> `Fuchsia store_path
   in
   (match serve, output with
-  | Enabled _, `Sexp _ -> raise_s [%message "cannot serve .sexp output"]
-  | _ -> ());
+   | Enabled _, `Sexp _ -> raise_s [%message "cannot serve .sexp output"]
+   | _ -> ());
   { serve; output }
 ;;
 

--- a/test/perf_script.ml
+++ b/test/perf_script.ml
@@ -66,14 +66,14 @@ let run ?(debug = false) ?ocaml_exception_info ~trace_scope file =
       (* Make the start of the trace start at time=0, regardless of when it actually started. *)
       let adjust_event_time (event : Event.t) : Event.t =
         Event.change_time event ~f:(fun event_time ->
-            let first_event_time =
-              match%optional.Time_ns.Span.Option !first_event_time with
-              | None ->
-                first_event_time := Time_ns.Span.Option.some event_time;
-                event_time
-              | Some first_event_time -> first_event_time
-            in
-            Time_ns.Span.( - ) event_time first_event_time)
+          let first_event_time =
+            match%optional.Time_ns.Span.Option !first_event_time with
+            | None ->
+              first_event_time := Time_ns.Span.Option.some event_time;
+              event_time
+            | Some first_event_time -> first_event_time
+          in
+          Time_ns.Span.( - ) event_time first_event_time)
       in
       let should_print_perf_line (event : Event.t) =
         match event with
@@ -87,19 +87,19 @@ let run ?(debug = false) ?ocaml_exception_info ~trace_scope file =
         Perf_decode.For_testing.split_line_pipe (Pipe.of_list lines) |> Pipe.to_list
       in
       List.iter split_lines ~f:(fun lines ->
-          let event =
-            Perf_decode.For_testing.to_event lines |> Option.map ~f:adjust_event_time
-          in
-          match event with
-          | Some event ->
-            if should_print_perf_line event
-            then (
-              match lines with
-              | [ line ] -> printf "%s\n" line
-              | lines -> print_s [%message (lines : string list)]);
-            let event = Event.With_write_info.create ~should_write:true event in
-            Trace_writer.write_event trace_writer event
-          | None -> ());
+        let event =
+          Perf_decode.For_testing.to_event lines |> Option.map ~f:adjust_event_time
+        in
+        match event with
+        | Some event ->
+          if should_print_perf_line event
+          then (
+            match lines with
+            | [ line ] -> printf "%s\n" line
+            | lines -> print_s [%message (lines : string list)]);
+          let event = Event.With_write_info.create ~should_write:true event in
+          Trace_writer.write_event trace_writer event
+        | None -> ());
       printf "END\n";
       Trace_writer.end_of_trace trace_writer)
 ;;

--- a/test/sample-targets/long-running/long_running.ml
+++ b/test/sample-targets/long-running/long_running.ml
@@ -48,8 +48,8 @@ let[@inline never] rec main_loop t n =
     if t.do_snap
     then Magic_trace.take_snapshot_with_time_and_arg (Time_stamp_counter.now ()) n;
     (match t.limit with
-    | Some limit when limit >= t.num_snaps -> ()
-    | _ -> main_loop { t with last_snap = now; num_snaps = t.num_snaps + 1 } (n + 1))
+     | Some limit when limit >= t.num_snaps -> ()
+     | _ -> main_loop { t with last_snap = now; num_snaps = t.num_snaps + 1 } (n + 1))
   | false ->
     if t.sleeps && n % 4000 = 0 then ignore (Core_unix.nanosleep 0.001 : float);
     main_loop t (n + 1)

--- a/test/test.ml
+++ b/test/test.ml
@@ -156,10 +156,10 @@ let dump_using_file ?range_symbols events =
   while%bind_open.Result Ok true do
     let%bind.Result cur = Tracing.Parser.parse_next parser in
     (match cur with
-    | Tick_initialization { ticks_per_second; base_time = _ } ->
-      (* Elide [base_time], since it isn't stable. *)
-      print_s [%message "Tick_initialization" (ticks_per_second : int)]
-    | _ -> print_s [%sexp (cur : Tracing.Parser.Record.t)]);
+     | Tick_initialization { ticks_per_second; base_time = _ } ->
+       (* Elide [base_time], since it isn't stable. *)
+       print_s [%message "Tick_initialization" (ticks_per_second : int)]
+     | _ -> print_s [%sexp (cur : Tracing.Parser.Record.t)]);
     Result.return ()
   done
   |> [%sexp_of: (unit, Tracing.Parser.Parse_error.t) Result.t]
@@ -793,13 +793,13 @@ let%expect_test "get debug information from ELF" =
   let debug_table =
     Magic_trace_core.Elf.addr_table (Option.value_exn elf)
     |> Hashtbl.filter ~f:(fun info ->
-           match info.filename with
-           | Some "sample.ml" -> true
-           | _ -> false)
+         match info.filename with
+         | Some "sample.ml" -> true
+         | _ -> false)
   in
   let raise_after_col =
     Hashtbl.filter_map debug_table ~f:(fun info ->
-        if info.line = 5 then Some info.col else None)
+      if info.line = 5 then Some info.col else None)
     |> Hashtbl.data
     |> List.hd_exn
   in


### PR DESCRIPTION
This bumps the version in `.ocamlformat` from 0.21 to 0.23. All the other diffs are a result of changes to how ocamlformat works.

Update: bumped it to the latest version, 0.24.1. This was the source of some of the CI failures.