### PR TITLE
Added ability to fuzzy find on line number based triggers

### DIFF
--- a/core/dune
+++ b/core/dune
@@ -1,7 +1,7 @@
 (library
  (name magic_trace_core)
  (public_name magic-trace.magic_trace_core)
- (libraries core async core_unix.filename_unix expect_test_helpers_core
+ (libraries core async core_unix.filename_unix expect_test_helpers_core fzf
    magic_trace owee re)
  (inline_tests)
  (preprocess

--- a/core/elf.ml
+++ b/core/elf.ml
@@ -136,6 +136,25 @@ let matching_functions t symbol_re =
   !res
 ;;
 
+let traverse_debug_line ~f t =
+  Option.iter t.debug ~f:(fun body ->
+      let cursor = Owee_buf.cursor body in
+      let pointers_to_other_sections =
+        Owee_elf.debug_line_pointers t.all_elf t.sections
+      in
+      let rec load_table_next () =
+        match Owee_debug_line.read_chunk cursor ~pointers_to_other_sections with
+        | None -> ()
+        | Some (header, chunk) ->
+          let process header (state : Owee_debug_line.state) () =
+            if not state.end_sequence then f header state
+          in
+          Owee_debug_line.fold_rows (header, chunk) process ();
+          load_table_next ()
+      in
+      load_table_next ())
+;;
+
 let find_symbol t name =
   let some_name = Some name in
   with_return (fun return ->
@@ -146,6 +165,81 @@ let find_symbol t name =
                   some_name
           then return.return (Some symbol));
       None)
+;;
+
+let find_selection t name : Selection.t option =
+  let maybe_int_of_string str = Option.try_with (fun () -> Int.of_string str) in
+  let find_line_selection name =
+    let desired_filename, desired_line, desired_col =
+      match String.split name ~on:':' with
+      | [ desired_filename; desired_line; desired_col ] ->
+        ( Some desired_filename
+        , maybe_int_of_string desired_line
+        , maybe_int_of_string desired_col )
+      | [ desired_filename; desired_line ] ->
+        Some desired_filename, maybe_int_of_string desired_line, None
+      | _ -> None, None, None
+    in
+    let%bind.Option desired_filename = desired_filename in
+    let%bind.Option desired_line = desired_line in
+    let cols = ref [] in
+    traverse_debug_line
+      ~f:(fun header state ->
+        let filename = Owee_debug_line.get_filename header state in
+        let line = state.line in
+        let col = state.col in
+        match filename with
+        | Some filename ->
+          if String.(desired_filename = filename) && desired_line = line
+          then cols := (col, state.address) :: !cols
+        | None -> ())
+      t;
+    let cols =
+      List.sort !cols ~compare:(fun (col1, _) (col2, _) -> Int.compare col1 col2)
+    in
+    match cols with
+    | [] -> None
+    | (col, address) :: _ ->
+      (match desired_col with
+      | None ->
+        if List.length cols > 1
+        then
+          Core.eprintf
+            "Multiple snapshot symbols on same line. Selecting column %d with address \
+             0x%x.\n"
+            col
+            address;
+        Some (Selection.Address { address; name })
+      | Some desired_col ->
+        (match
+           List.find_map cols ~f:(fun (col, _) ->
+               if col = desired_col then Some address else None)
+         with
+        | None -> None
+        | Some address -> Some (Selection.Address { address; name })))
+  in
+  let find_addr_selection name =
+    Option.bind
+      (Option.try_with (fun () -> Int.Hex.of_string name))
+      ~f:(fun address -> Some (Selection.Address { address; name }))
+  in
+  let find_symbol_selection name =
+    Option.map (find_symbol t name) ~f:(fun symbol -> Selection.Symbol symbol)
+  in
+  let prefix_and_functions =
+    [ "symbol:", find_symbol_selection
+    ; "line:", find_line_selection
+    ; "addr:", find_addr_selection
+    ]
+  in
+  match
+    List.find_map prefix_and_functions ~f:(fun (prefix, f) ->
+        match String.is_prefix name ~prefix with
+        | true -> f (String.drop_prefix name (String.length prefix))
+        | false -> None)
+  with
+  | Some _ as result -> result
+  | None -> List.find_map prefix_and_functions ~f:(fun ((_prefix : string), f) -> f name)
 ;;
 
 let all_symbols t =
@@ -163,12 +257,9 @@ let all_symbols t =
   String.Table.to_alist res
 ;;
 
-let symbol_stop_info t pid symbol =
-  let name = Owee_elf.Symbol_table.Symbol.name symbol t.string in
-  let name = Option.value_exn ~message:"stop_info symbols must have a name" name in
+let selection_stop_info t pid selection =
   let filename = Filename_unix.realpath t.filename in
-  let addr = Owee_elf.Symbol_table.Symbol.value symbol in
-  let addr =
+  let compute_addr addr =
     if t.statically_mappable
     then addr
     else
@@ -181,49 +272,46 @@ let symbol_stop_info t pid symbol =
              else None)
       |> List.hd_exn
   in
-  let size = Owee_elf.Symbol_table.Symbol.size_in_bytes symbol in
-  let offset = Int64.( - ) addr (Int64.of_int t.base_offset) in
-  let filter = [%string {|stop %{offset#Int64}/%{size#Int64}@%{filename}|}] in
-  { Stop_info.name; addr; filter }
+  let compute_filter ~name ~addr ~size =
+    let offset = Int64.( - ) addr (Int64.of_int t.base_offset) in
+    let filter = [%string {|stop %{offset#Int64}/%{size#Int64}@%{filename}|}] in
+    { Stop_info.name; addr; filter }
+  in
+  match selection with
+  | Selection.Symbol symbol ->
+    let name = Owee_elf.Symbol_table.Symbol.name symbol t.string in
+    let name = Option.value_exn ~message:"stop_info symbols must have a name" name in
+    let addr = Owee_elf.Symbol_table.Symbol.value symbol in
+    let addr = compute_addr addr in
+    let size = Owee_elf.Symbol_table.Symbol.size_in_bytes symbol in
+    compute_filter ~name ~addr ~size
+  | Address { address; name } ->
+    let addr = compute_addr (Int64.of_int address) in
+    compute_filter ~name ~addr ~size:1L
 ;;
 
 let addr_table t =
   let table = Int.Table.create () in
-  Option.iter t.debug ~f:(fun body ->
-      (* We only want to include line info from the start address of symbols in the table,
-       lest it grow too large on big executables. We don't need to include mappings for
-       lines in the middle of functions. *)
-      let symbol_starts = Int.Hash_set.create () in
-      Owee_elf.Symbol_table.iter t.symbol ~f:(fun symbol ->
-          if is_func symbol
-          then
-            Hash_set.add
-              symbol_starts
-              (Owee_elf.Symbol_table.Symbol.value symbol |> Int64.to_int_exn));
-      let cursor = Owee_buf.cursor body in
-      let pointers_to_other_sections =
-        Owee_elf.debug_line_pointers t.all_elf t.sections
-      in
-      let rec load_table_next () =
-        match Owee_debug_line.read_chunk cursor ~pointers_to_other_sections with
-        | None -> ()
-        | Some (header, chunk) ->
-          let process header (state : Owee_debug_line.state) () =
-            if (not state.end_sequence) && Hash_set.mem symbol_starts state.address
-            then
-              Hashtbl.set
-                table
-                ~key:state.address
-                ~data:
-                  { Location.filename = Owee_debug_line.get_filename header state
-                  ; line = state.line
-                  ; col = state.col
-                  }
-          in
-          Owee_debug_line.fold_rows (header, chunk) process ();
-          load_table_next ()
-      in
-      load_table_next ());
+  let symbol_starts = Int.Hash_set.create () in
+  Owee_elf.Symbol_table.iter t.symbol ~f:(fun symbol ->
+      if is_func symbol
+      then
+        Hash_set.add
+          symbol_starts
+          (Owee_elf.Symbol_table.Symbol.value symbol |> Int64.to_int_exn));
+  traverse_debug_line
+    ~f:(fun header state ->
+      if Hash_set.mem symbol_starts state.address
+      then
+        Hashtbl.set
+          table
+          ~key:state.address
+          ~data:
+            { Location.filename = Owee_debug_line.get_filename header state
+            ; line = state.line
+            ; col = state.col
+            })
+    t;
   table
 ;;
 

--- a/core/elf.mli
+++ b/core/elf.mli
@@ -20,7 +20,16 @@ val ocaml_exception_info : t -> Ocaml_exception_info.t option
     suitable for asking the user to disambiguate. *)
 val matching_functions : t -> Re.re -> Owee_elf.Symbol_table.Symbol.t String.Map.t
 
-val all_symbols : t -> (string * Owee_elf.Symbol_table.Symbol.t) list
+val all_symbols
+  :  ?select:[ `File | `Func | `File_or_func ] (** Default [`File_or_func]. *)
+  -> t
+  -> (string * Owee_elf.Symbol_table.Symbol.t) list
+
+val all_file_selections
+  :  t
+  -> Owee_elf.Symbol_table.Symbol.t
+  -> (string * Selection.t) list
+
 val find_symbol : t -> string -> Owee_elf.Symbol_table.Symbol.t option
 val find_selection : t -> string -> Selection.t option
 

--- a/core/elf.mli
+++ b/core/elf.mli
@@ -11,7 +11,7 @@ val create : Filename.t -> t option
     to stop when executing code from that symbol. The filter string syntax is in ftrace
     format and is accepted both by the perf command line tool and the
     [PERF_EVENT_IOC_SET_FILTER] ioctl for the [perf_event_open] syscall. *)
-val symbol_stop_info : t -> Pid.t -> Owee_elf.Symbol_table.Symbol.t -> Stop_info.t
+val selection_stop_info : t -> Pid.t -> Selection.t -> Stop_info.t
 
 val addr_table : t -> Addr_table.t
 val ocaml_exception_info : t -> Ocaml_exception_info.t option
@@ -22,6 +22,7 @@ val matching_functions : t -> Re.re -> Owee_elf.Symbol_table.Symbol.t String.Map
 
 val all_symbols : t -> (string * Owee_elf.Symbol_table.Symbol.t) list
 val find_symbol : t -> string -> Owee_elf.Symbol_table.Symbol.t option
+val find_selection : t -> string -> Selection.t option
 
 module Symbol_resolver : sig
   type nonrec t =

--- a/core/elf_intf.ml
+++ b/core/elf_intf.ml
@@ -20,3 +20,12 @@ module Stop_info = struct
     ; filter : string
     }
 end
+
+module Selection = struct
+  type t =
+    | Symbol of Owee_elf.Symbol_table.Symbol.t
+    | Address of
+        { address : int
+        ; name : string
+        }
+end

--- a/core/symbol_selection.ml
+++ b/core/symbol_selection.ml
@@ -1,12 +1,73 @@
 open! Core
+open! Async
 
 type t =
-  | Use_fzf_to_select_one
+  | Use_fzf_to_select_one of [ `File | `Func | `File_or_func ]
   | User_selected of string
 
 let of_command_string s =
   match s with
-  | "?" -> Use_fzf_to_select_one
+  | "?" -> Use_fzf_to_select_one `File_or_func
+  | "line:?" -> Use_fzf_to_select_one `File
+  | "symbol:?" -> Use_fzf_to_select_one `Func
   | "." -> User_selected Magic_trace.Private.stop_symbol
   | s -> User_selected s
+;;
+
+let select_owee_symbol ~elf ~header select =
+  let open Deferred.Or_error.Let_syntax in
+  let all_symbols = Elf.all_symbols ~select elf in
+  let all_symbol_names = List.map all_symbols ~f:Tuple2.get1 in
+  match%bind Fzf.pick_one ~header (Inputs all_symbol_names) with
+  | None -> Deferred.Or_error.error_string "No symbol selected"
+  | Some chosen_name ->
+    let chosen_symbol =
+      List.find_exn all_symbols ~f:(fun (name, _symbol) -> String.(name = chosen_name))
+      |> Tuple2.get2
+    in
+    return (chosen_name, chosen_symbol)
+;;
+
+let select_within_file ~elf ~header symbol =
+  let open Deferred.Or_error.Let_syntax in
+  let all_file_selections = Elf.all_file_selections elf symbol in
+  let all_file_selection_names = List.map all_file_selections ~f:Tuple2.get1 in
+  let%bind () =
+    if List.is_empty all_file_selections
+    then
+      Deferred.Or_error.error_string
+        "No lines found, possibly because of missing debug info"
+    else return ()
+  in
+  match%bind Fzf.pick_one ~header (Inputs all_file_selection_names) with
+  | None -> Deferred.Or_error.error_string "No location selected"
+  | Some chosen_name -> return chosen_name
+;;
+
+let evaluate ~supports_fzf ~elf ~header symbol_selection =
+  let open Deferred.Or_error.Let_syntax in
+  let%bind elf =
+    match elf with
+    | None -> Deferred.Or_error.error_string "No ELF found"
+    | Some elf -> return elf
+  in
+  let%bind () =
+    if force supports_fzf
+    then return ()
+    else
+      Deferred.Or_error.error_string
+        "magic-trace could show you a fuzzy-finding selector here if \"fzf\" were in \
+         your PATH, but it is not."
+  in
+  match symbol_selection with
+  | Use_fzf_to_select_one select ->
+    let%bind chosen_name, chosen_symbol = select_owee_symbol ~elf ~header select in
+    (match Owee_elf.Symbol_table.Symbol.type_attribute chosen_symbol with
+    | File ->
+      let%bind chosen_name =
+        select_within_file ~elf ~header:(header ^ " line") chosen_symbol
+      in
+      return chosen_name
+    | _ -> return chosen_name)
+  | User_selected user_selection -> return user_selection
 ;;

--- a/core/symbol_selection.mli
+++ b/core/symbol_selection.mli
@@ -1,7 +1,15 @@
 open! Core
+open! Async
 
 type t =
-  | Use_fzf_to_select_one
+  | Use_fzf_to_select_one of [ `File | `Func | `File_or_func ]
   | User_selected of string
 
 val of_command_string : string -> t
+
+val evaluate
+  :  supports_fzf:bool lazy_t
+  -> elf:Elf.t option
+  -> header:string
+  -> t
+  -> string Deferred.Or_error.t

--- a/core/when_to_snapshot.ml
+++ b/core/when_to_snapshot.ml
@@ -17,11 +17,13 @@ let param =
        (2) If you provide [-trigger ?], magic-trace will open up a fuzzy-find dialog to \
        help you choose a symbol to trace. Fails if you don't have the \"fzf\" binary in \
        your PATH.\n\
-       (3) If you provide [-trigger <FUNCTION NAME>], magic-trace will snapshot when the \
+       (3) If you provide [-trigger <SELECTION>], magic-trace will snapshot when the \
        application being traced calls the given function. This takes the fully-mangled \
        name, so if you're using anything except C, fuzzy-find mode will probably be \
        easier to use. [-trigger .] is a shorthand for [-trigger \
-       magic_trace_stop_indicator].\n\
+       magic_trace_stop_indicator]. [SELECTION] can be [<FUNCTION NAME>], [<ADDRESS>], \
+       or [<FILE>:<LINE>:<COL>]. Prefixes [addr:], [symbol:], and [line:] restrict how \
+       magic-trace should parse the selection.\n\
        (*) Regardless of trigger mode, magic-trace will always snapshot when the \
        application terminates if it has not yet triggered for any other reason."
   |> map ~f:(function

--- a/core/when_to_snapshot.ml
+++ b/core/when_to_snapshot.ml
@@ -14,9 +14,10 @@ let param =
        from:\n\
        (1) If you do not provide [-trigger], magic-trace takes a snapshot when you \
        Ctrl+C it.\n\
-       (2) If you provide [-trigger ?], magic-trace will open up a fuzzy-find dialog to \
-       help you choose a symbol to trace. Fails if you don't have the \"fzf\" binary in \
-       your PATH.\n\
+       (2) If you provide [-trigger ?], [-trigger symbol:?], or [-trigger line:?], \
+       magic-trace will open up a fuzzy-find dialog to help you choose a symbol to \
+       trace. Fails if you don't have the \"fzf\" binary in your PATH. The prefixes \
+       [symbol:] and [line:] restrict to showing only functions or files respectively.\n\
        (3) If you provide [-trigger <SELECTION>], magic-trace will snapshot when the \
        application being traced calls the given function. This takes the fully-mangled \
        name, so if you're using anything except C, fuzzy-find mode will probably be \

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -328,11 +328,11 @@ module Make_commands (Backend : Backend_intf.S) = struct
           let%bind snap_sym =
             Deferred.return
               (Result.of_option
-                 (Elf.find_symbol elf symbol_name)
+                 (Elf.find_selection elf symbol_name)
                  ~error:
                    (Error.of_string [%string "Snapshot symbol not found: %{symbol_name}"]))
           in
-          let snap_loc = Elf.symbol_stop_info elf head_pid snap_sym in
+          let snap_loc = Elf.selection_stop_info elf head_pid snap_sym in
           return (Some snap_loc))
     in
     let%map.Deferred.Or_error recording, recording_data =


### PR DESCRIPTION
DRAFT: Rebased on #241.

This feature adds the ability to specify trigger modes like `-trigger line:?` and `-trigger symbol:?` which will cause fzf to only shows files or functions respectively. If `-trigger ?` is passed, it will show both. However if the user selects a file, there is another prompt for them to select the source location to break on.