### PR TITLE
destinations.ml: add a compressed_file_destination that uses zstandard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.opam
-          key: ${{ matrix.os }}-opam-${{ matrix.ocaml-version }}-flambda-musl-v5
+          key: ${{ matrix.os }}-opam-${{ matrix.ocaml-version }}-flambda-musl-v6
 
       - name: Install musl-compatible kernel headers
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Use OCaml ${{ matrix.ocaml-version }}
         run: |
           sudo apt-get update
-          sudo apt-get install bubblewrap musl-tools
+          sudo apt-get install bubblewrap musl-tools libzstd-dev
           sudo wget -O /usr/local/bin/opam https://github.com/ocaml/opam/releases/download/2.1.2/opam-2.1.2-x86_64-linux
           sudo chmod a+x /usr/local/bin/opam
 

--- a/magic-trace.opam
+++ b/magic-trace.opam
@@ -20,6 +20,7 @@ depends: [
   "crunch"
   "ppx_jane"
   "shell"
+  "zstandard"
   "dune"         {>= "2.0.0"}
   "owee"         {>= "0.6"}
   "re"           {>= "1.8.0"}

--- a/src/tracing_tool_output.ml
+++ b/src/tracing_tool_output.ml
@@ -167,7 +167,11 @@ let write_and_maybe_serve ?num_temp_strs t ~filename ~f_sexp ~f_fuchsia =
      serving the new trace, which is unlikely to be what the user expected. *)
     let indirect_store_path = [%string "/proc/self/fd/%{fd#Core_unix.File_descr}"] in
     let w =
-      Tracing_zero.Writer.create_for_file ?num_temp_strs ~filename:indirect_store_path ()
+      Tracing_zero.Writer.create_for_file
+        ?num_temp_strs
+        ~filename:indirect_store_path
+        ~original_filename:store_path
+        ()
     in
     let%bind res = f_fuchsia w in
     let%map () =

--- a/vendor/tracing/src/tool_output.ml
+++ b/vendor/tracing/src/tool_output.ml
@@ -28,7 +28,13 @@ let param =
 
 let write_and_view ?num_temp_strs { store_path } ~default_name:_ ~f =
   let open Deferred.Or_error.Let_syntax in
-  let w = Tracing_zero.Writer.create_for_file ?num_temp_strs ~filename:store_path () in
+  let w =
+    Tracing_zero.Writer.create_for_file
+      ?num_temp_strs
+      ~filename:store_path
+      ~original_filename:store_path
+      ()
+  in
   let%map res = f w in
   Core.eprintf "Visit https://ui.perfetto.dev/ and open %s to view trace.\n%!" store_path;
   res

--- a/vendor/tracing/src/trace.ml
+++ b/vendor/tracing/src/trace.ml
@@ -43,7 +43,7 @@ let create ~base_time writer =
 ;;
 
 let create_for_file ~base_time ~filename =
-  let writer = TW.create_for_file ~filename () in
+  let writer = TW.create_for_file ~filename ~original_filename:filename () in
   create ~base_time writer
 ;;
 

--- a/vendor/tracing/zero/destinations.mli
+++ b/vendor/tracing/zero/destinations.mli
@@ -8,7 +8,7 @@ val direct_file_destination
   -> (module Writer_intf.Destination)
 
 (** Write to a file in some way with the best available performance. *)
-val file_destination : filename:string -> unit -> (module Writer_intf.Destination)
+val file_destination : filename:string -> original_filename:string -> unit -> (module Writer_intf.Destination)
 
 (** Write to a provided [Iobuf.t], throws an exception if the buffer runs out of space.
     Mostly intended for use in tests. After the [Destination] is closed, sets the window

--- a/vendor/tracing/zero/dune
+++ b/vendor/tracing/zero/dune
@@ -1,4 +1,4 @@
 (library (name tracing_zero) (public_name tracing.tracing_zero)
  (preprocess (pps ppx_jane))
  (libraries core core_kernel.iobuf core_unix.iobuf_unix
-  core_unix.time_stamp_counter))
+  core_unix.time_stamp_counter zstandard))

--- a/vendor/tracing/zero/writer.ml
+++ b/vendor/tracing/zero/writer.ml
@@ -618,8 +618,8 @@ module Expert = struct
   module Write_arg_unchecked = Write_arg_unchecked
 end
 
-let create_for_file ?num_temp_strs ~filename () =
-  let destination = Destinations.file_destination ~filename () in
+let create_for_file ?num_temp_strs ~filename ~original_filename () =
+  let destination = Destinations.file_destination ~filename ~original_filename () in
   Expert.create ?num_temp_strs ~destination ()
 ;;
 

--- a/vendor/tracing/zero/writer.mli
+++ b/vendor/tracing/zero/writer.mli
@@ -14,7 +14,7 @@ type t
 (** Allocates a writer which writes to [filename] with [num_temp_strs] temporary string
     slots (see [set_temp_string_slot]), with increases in [num_temp_strs] reducing the
     number of strings which can be allocated with [intern_string]. *)
-val create_for_file : ?num_temp_strs:int -> filename:string -> unit -> t
+val create_for_file : ?num_temp_strs:int -> filename:string -> original_filename:string -> unit -> t
 
 val close : t -> unit
 


### PR DESCRIPTION
Trace files can be large and hard to share. Using zstd to compress trace
files allows users to decrease their file sizes, as demonstrated here:

```
$ du -sh trace.fxt trace.fxt.zst
472K    trace.fxt
56K     trace.fxt.zst
```

This is a preliminary attempt at adding a compressed file destination.
We have some open questions that we want to raise in the PR.

One thing we had to do is we had to make an `original_filename` labeled
argument. This is because, sometimes, magic-trace uses
`/proc/self/fd/$FD` paths as a way to prevent a race condition when
serving traces.