### PR TITLE
.github/workflows/build.yml: download upx 3.96-2 from ftp.debian.org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.opam
-          key: ${{ matrix.os }}-opam-${{ matrix.ocaml-version }}-flambda-musl-v4
+          key: ${{ matrix.os }}-opam-${{ matrix.ocaml-version }}-flambda-musl-v5
 
       - name: Install musl-compatible kernel headers
         run: |
@@ -32,8 +32,9 @@ jobs:
 
       - name: Install upx
         run: |
-          # The version that comes with focal is broken for musl binaries, pulling 3.96 from hirsute.
-          wget http://azure.archive.ubuntu.com/ubuntu/pool/universe/u/upx-ucl/upx-ucl_3.96-2_amd64.deb
+          # The version that comes with focal is broken for musl binaries, so we have to download
+          # from another location.
+          wget http://ftp.debian.org/debian/pool/main/u/upx-ucl/upx-ucl_3.96-2_amd64.deb
           sudo dpkg -i upx-ucl_3.96-2_amd64.deb
 
       - name: Use OCaml ${{ matrix.ocaml-version }}


### PR DESCRIPTION
The old URL disappeared, but this new location appears to work (when I tested it on my personal GitHub repo's CI). I'm not sure how relevant the old comment about musl is -- I didn't investigate deeply. To cover all the bases, I tweaked the comment slightly to just indicate that we're not using the default Ubuntu UPX. I'm guessing the Debian package is just built differently from the Ubuntu equivalent, but, again, didn't investigate too deeply. 