### PR TITLE
Unwind the stack for caml_stash_backtrace

### DIFF
--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -748,6 +748,7 @@ end = struct
           (match symbol with
            | "caml_next_frame_descriptor" -> incr frames_to_unwind
            | "caml_raise_exn" -> unwind_stack t thread_info ~time ~frames_to_unwind (-2)
+           | "caml_stash_backtrace" -> incr frames_to_unwind
            | "caml_raise_exception" ->
              unwind_stack t thread_info ~time ~frames_to_unwind 1
            | _ -> ())


### PR DESCRIPTION
In hacky ocaml-exception-detection mode, unwind the stack one more level for caml_stash_backtrace. I did some digging in core_unix and I'm not actually sure when this changed, but traces are stairstep for the following trivial async program without this quick patch.

```ocaml
open! Core
open! Async

let rec go () =
    Reader.open_file "a.txt"
    >>= fun a ->
    Writer.open_file "b.txt"
    >>= fun b ->
    let p1 = Reader.lines a in
    Pipe.iter p1 ~f:(fun line ->
        Writer.write_line b line;
        Writer.flushed b)
    >>= fun () ->
    Reader.close a
    >>= fun () ->
    Writer.close b
    >>= fun () ->
    Unix.rename ~src:"b.txt" ~dst:"a.txt"
    >>= fun () ->
    go ()

let command =
    Command.async ~summary:"" (Command.Param.return go)

let () =
  Command_unix.run command
```

If you run this, you'll need to put some lines of text in a.txt before running it.