### PR TITLE
Add optional command arguments in the end for "attach" command

### DIFF
--- a/core/backend_intf.ml
+++ b/core/backend_intf.ml
@@ -20,6 +20,7 @@ module type S = sig
 
     val attach_and_record
       :  Record_opts.t
+      -> cmd:string list option
       -> debug_print_perf_commands:bool
       -> subcommand:Subcommand.t
       -> when_to_snapshot:When_to_snapshot.t

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -215,6 +215,7 @@ module Recording = struct
 
   let attach_and_record
     { Record_opts.multi_thread; full_execution; snapshot_size; callgraph_mode }
+    ~(cmd : string list option)
     ~debug_print_perf_commands
     ~(subcommand : Subcommand.t)
     ~(when_to_snapshot : When_to_snapshot.t)
@@ -376,6 +377,11 @@ module Recording = struct
       | true -> [ "--switch-output=signal" ]
       | false -> []
     in
+    let commands =
+      match cmd with
+      | Some x -> x
+      | None -> []
+    in
     let argv =
       List.concat
         [ [ "perf"; "record"; "-o"; record_dir ^/ "perf.data"; "--timestamp" ]
@@ -388,6 +394,7 @@ module Recording = struct
         ; kcore_opts
         ; snapshot_size_opt
         ; Callgraph_mode.to_perf_record_args selected_callgraph_mode
+        ; commands
         ]
     in
     if debug_print_perf_commands then Core.printf "%s\n%!" (String.concat ~sep:" " argv);

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -312,6 +312,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
 
   let attach
     (opts : Record_opts.t)
+    ~cmd
     ~elf
     ~debug_print_perf_commands
     ~subcommand
@@ -349,6 +350,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
     let%map.Deferred.Or_error recording, recording_data =
       Backend.Recording.attach_and_record
         opts.backend_opts
+        ~cmd
         ~debug_print_perf_commands
         ~subcommand
         ~when_to_snapshot:opts.when_to_snapshot
@@ -442,9 +444,11 @@ module Make_commands (Backend : Backend_intf.S) = struct
     =
     let open Deferred.Or_error.Let_syntax in
     let pid = Ptrace.fork_exec_stopped ~prog ~argv () in
+    let cmd = None in
     let%bind attachment =
       attach
         record_opts
+        ~cmd
         ~elf
         ~debug_print_perf_commands
         ~subcommand:Run
@@ -482,10 +486,11 @@ module Make_commands (Backend : Backend_intf.S) = struct
     return pid
   ;;
 
-  let attach_and_record record_opts ~elf ~debug_print_perf_commands ~collection_mode pids =
+  let attach_and_record record_opts ~cmd ~elf ~debug_print_perf_commands ~collection_mode pids =
     let%bind.Deferred.Or_error attachment =
       attach
         record_opts
+        ~cmd
         ~elf
         ~debug_print_perf_commands
         ~subcommand:Attach
@@ -676,10 +681,13 @@ module Make_commands (Backend : Backend_intf.S) = struct
          magic-trace attach\n\n\
          # Fuzzy-find to select a running process and symbol to trigger on, snapshotting \
          the next time the symbol is called\n\
-         magic-trace attach -trigger ?\n")
+         magic-trace attach -trigger ?\n\n\
+         # Add a command in the end to forward it to perf\n\
+         magic-trace attach -trigger sym sleep 5\n\n")
       (let%map_open.Command record_opt_fn = record_flags
        and decode_opts = decode_flags
        and debug_print_perf_commands = debug_print_perf_commands
+       and cmd = (anon (maybe (sequence ("command" %: string ))))
        and pids =
          flag
            "-pid"
@@ -717,6 +725,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
              let%bind () =
                attach_and_record
                  opts
+                 ~cmd
                  ~elf
                  ~debug_print_perf_commands
                  ~collection_mode


### PR DESCRIPTION
This PR adds extra arguments at the end of "attach" command, and these will be forwarded on to `perf` verbatim. Therefore, we can now use the following command

```
$ magic-trace attach -p $(pidof foo) -trigger bar sleep 5
```

The perf command called under the hood would be

```
perf <args> sleep 5
```