### PR TITLE
Handle `tr end  async` trace events

### DIFF
--- a/core/event.ml
+++ b/core/event.ml
@@ -2,6 +2,7 @@ open! Core
 
 module Kind = struct
   type t =
+    | Async
     | Call
     | Return
     | Syscall

--- a/core/event.mli
+++ b/core/event.mli
@@ -2,6 +2,7 @@ open! Core
 
 module Kind : sig
   type t =
+    | Async
     | Call
     | Return
     | Syscall

--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -1029,8 +1029,10 @@ let write_event (T t) ?events_writer event =
          ~time;
        (match kind, trace_state_change with
         | Some Call, (None | Some End) -> call t thread_info ~time ~location:dst
-        | ( Some (Call | Syscall | Return | Hardware_interrupt | Iret | Sysret | Jump)
+        | ( Some
+              (Async | Call | Syscall | Return | Hardware_interrupt | Iret | Sysret | Jump)
           , Some Start )
+        | Some Async, None
         | Some (Hardware_interrupt | Jump), Some End ->
           raise_s
             [%message
@@ -1038,7 +1040,8 @@ let write_event (T t) ?events_writer event =
                proved them wrong. Please report this to \
                https://github.com/janestreet/magic-trace/issues/"
                 (event : Event.t)]
-        | None, Some End -> call t thread_info ~time ~location:Event.Location.untraced
+        | (None | Some Async), Some End ->
+          call t thread_info ~time ~location:Event.Location.untraced
         | Some Syscall, Some End ->
           (* We should only be getting these under /u *)
           assert_trace_scope t outer_event [ Userspace ];


### PR DESCRIPTION
Kernel commit

https://lore.kernel.org/lkml/20230928072953.19369-1-adrian.hunter@intel.com/

set `PERF_IP_FLAG_ASYNC` on trace end events. As per

https://github.com/torvalds/linux/blob/7ee022567bf9e2e0b3cd92461a2f4986ecc99673/tools/perf/builtin-script.c#L1546

I think this means that where `perf` would have previously outputted `tr end  jmp`, it now outputs `tr end  async`.

Adjust our regex to allow `async`, and treat it as a branch.