### PR TITLE
Do not display extremely long commandline arguments

### DIFF
--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -522,7 +522,10 @@ let create_thread t event =
        | None -> default_name
        | Some cmdline ->
          let concat_cmdline = String.concat ~sep:" " cmdline in
-         [%string "%{concat_cmdline} %{default_name}"])
+         let name = [%string "%{concat_cmdline} %{default_name}"] in
+         if String.length name > Tracing_zero.Writer.max_interned_string_length
+         then default_name
+         else name)
   in
   let track_group_id = allocate_pid t ~name in
   let thread = allocate_thread t ~pid:track_group_id ~name:"main" in

--- a/vendor/tracing/zero/writer.ml
+++ b/vendor/tracing/zero/writer.ml
@@ -149,10 +149,12 @@ module String_id = struct
   let max_number_of_temp_string_slots = max_value - first_temp + 1
 end
 
+(* maximum string length defined in spec, somewhat less than 2**15 *)
+let max_interned_string_length = 32000 - 1
+
 let set_string_slot t ~string_id s =
   let str_len = String.length s in
-  (* maximum string length defined in spec, somewhat less than 2**15 *)
-  if str_len >= 32000
+  if str_len > max_interned_string_length
   then failwithf "string too long for FTF trace: %i is over the limit of 32kb" str_len ();
   (* String record *)
   let rtype = 2 in

--- a/vendor/tracing/zero/writer.mli
+++ b/vendor/tracing/zero/writer.mli
@@ -29,6 +29,8 @@ module String_id : sig
   val max_number_of_temp_string_slots : int
 end
 
+val max_interned_string_length : int
+
 (** Intern a string into the trace so that it can be referred to with very low cost.
     Note that this does not check if the string has already been interned, see
     [intern_string_cached].


### PR DESCRIPTION
Otherwise, the trace writer will raise because we're violating the Perfetto trace file format.

I opted to not show the arguments at all because it was slightly simpler, and it is unlikely the 60-something characters Perfetto would display in the UI would be particularly enlightening for a commandline that's longer than 32 KiB.

Closes https://github.com/janestreet/magic-trace/issues/286.