### PR TITLE
Handle tsx transactions

### DIFF
--- a/src/env_vars.ml
+++ b/src/env_vars.ml
@@ -42,3 +42,8 @@ let fzf_demangle_symbols = Option.is_some (Unix.getenv "MAGIC_TRACE_FZF_DEMANGLE
 let no_ocaml_exception_debug_info =
   Option.is_some (Unix.getenv "MAGIC_TRACE_NO_OCAML_EXCEPTION_DEBUG_INFO")
 ;;
+
+(* Skip any special case transaction handling, intended for debugging tx/tx_abrt. *)
+let skip_transaction_handling =
+  Option.is_some (Unix.getenv "MAGIC_TRACE_SKIP_TX_HANDLING")
+;;

--- a/src/env_vars.mli
+++ b/src/env_vars.mli
@@ -9,3 +9,4 @@ val perfetto_dir : string option
 val no_dlfilter : bool
 val fzf_demangle_symbols : bool
 val no_ocaml_exception_debug_info : bool
+val skip_transaction_handling : bool

--- a/src/event.ml
+++ b/src/event.ml
@@ -10,6 +10,7 @@ module Kind = struct
     | Hardware_interrupt
     | Iret
     | Jump
+    | Tx_abort
   [@@deriving sexp, compare, bin_io]
 end
 
@@ -88,6 +89,7 @@ module Ok = struct
     { thread : Thread.t
     ; time : Time_ns.Span.t
     ; data : Data.t
+    ; in_transaction : bool [@sexp.bool]
     }
   [@@deriving sexp, bin_io]
 end

--- a/src/event.mli
+++ b/src/event.mli
@@ -10,6 +10,7 @@ module Kind : sig
     | Hardware_interrupt
     | Iret
     | Jump
+    | Tx_abort
   [@@deriving sexp, compare]
 end
 
@@ -60,6 +61,7 @@ module Ok : sig
     { thread : Thread.t
     ; time : Time_ns.Span.t
     ; data : Data.t
+    ; in_transaction : bool
     }
   [@@deriving sexp]
 end

--- a/test/decode_errors.ml
+++ b/test/decode_errors.ml
@@ -5,6 +5,7 @@ let%expect_test "decode error during memmove" =
   let%map () = Perf_script.run ~trace_scope:Userspace "memmove_decode_error.perf" in
   [%expect
     {|
+    Warning: perf reported an error decoding the trace: 'Overflow packet' @ IP 0x7ffff7327730.
     293415/293415 47170.086912824:                            1   branches:uH:   call                           40b06c itch_bbo::book::Book::add_order+0x51c (foo.so) =>     7ffff7327730 __memmove_avx_unaligned_erms+0x0 (foo.so)
     293415/293415 47170.086912825:                            1   branches:uH:   return                   7ffff73277c7 __memmove_avx_unaligned_erms+0x97 (foo.so) =>           40b072 itch_bbo::book::Book::add_order+0x522 (foo.so)
     ->     19ns BEGIN __memmove_avx_unaligned_erms
@@ -23,9 +24,7 @@ let%expect_test "decode error during memmove" =
     INPUT TRACE STREAM ENDED, any lines printed below this were deferred
     ->     21ns BEGIN itch_bbo::book::Book::add_order [inferred start time]
     ->    141ns END   __memmove_avx_unaligned_erms
-    ->    141ns END   itch_bbo::book::Book::add_order
-    Warning: perf reported an error decoding the trace: 'Overflow packet' @ IP 0x7ffff7327730.
-    ! |}]
+    ->    141ns END   itch_bbo::book::Book::add_order |}]
 ;;
 
 let%expect_test "decode error during rust B-tree rebalance" =
@@ -34,6 +33,8 @@ let%expect_test "decode error during rust B-tree rebalance" =
   in
   [%expect
     {|
+    Warning: perf reported an error decoding the trace: 'Overflow packet' @ IP 0x7ffff7327730.
+    Warning: perf reported an error decoding the trace: 'Overflow packet' @ IP 0x7ffff7327730.
     364691/364691 62709.735347729:                            1   branches:uH:   call                           40bc5a itch_bbo::book::Book::delete_order+0x3ca (foo.so) =>           40a550 remove_leaf_kv+0x0 (foo.so)
     364691/364691 62709.735347731:                            1   branches:uH:   call                           40a5b2 remove_leaf_kv+0x62 (foo.so) =>     7ffff7327730 __memmove_avx_unaligned_erms+0x0 (foo.so)
     ->     28ns BEGIN remove_leaf_kv
@@ -97,8 +98,5 @@ let%expect_test "decode error during rust B-tree rebalance" =
     ->    419ns END   _int_free
     ->    419ns END   merge_tracking_child_edge
     ->    420ns END   remove_leaf_kv
-    INPUT TRACE STREAM ENDED, any lines printed below this were deferred
-    Warning: perf reported an error decoding the trace: 'Overflow packet' @ IP 0x7ffff7327730.
-    !Warning: perf reported an error decoding the trace: 'Overflow packet' @ IP 0x7ffff7327730.
-    ! |}]
+    INPUT TRACE STREAM ENDED, any lines printed below this were deferred |}]
 ;;

--- a/test/page_fault.ml
+++ b/test/page_fault.ml
@@ -5,6 +5,7 @@ let%expect_test "A page fault during demo.c" =
   let%map () = Perf_script.run ~trace_scope:Userspace_and_kernel "page_fault.perf" in
   [%expect
     {|
+    Warning: perf reported an error decoding the trace: 'Overflow packet (foo.so)' @ IP 0x7f5948676e18.
     1439745/1439745 2472089.651284813:                            1   branches:uH:   jmp                      7f59488f90f7 call_destructors+0x67 (foo.so) =>     7f5948676e18 _fini+0x0 (foo.so)
      instruction trace error type 1 time 2472089.651285037 cpu -1 pid 1439745 tid 1439745 ip 0x7f5948676e18 code 7: Overflow packet (foo.so)
     ->    224ns BEGIN [decode error: Overflow packet (foo.so)]
@@ -643,7 +644,5 @@ let%expect_test "A page fault during demo.c" =
     ->    224ns BEGIN _dl_catch_exception [inferred start time]
     ->    224ns BEGIN _fini [inferred start time]
     ->  1.373us END   _fini
-    ->  1.373us END   _dl_catch_exception
-    Warning: perf reported an error decoding the trace: 'Overflow packet (foo.so)' @ IP 0x7f5948676e18.
-    ! |}]
+    ->  1.373us END   _dl_catch_exception |}]
 ;;

--- a/test/test.ml
+++ b/test/test.ml
@@ -63,6 +63,7 @@ end = struct
           ; src = random_location ()
           ; dst = random_location ?symbol ()
           }
+    ; in_transaction = false
     }
   ;;
 
@@ -94,6 +95,7 @@ end = struct
          { thread
          ; time
          ; data = Trace { trace_state_change = None; kind = Some kind; src; dst }
+         ; in_transaction = false
          })
   ;;
 


### PR DESCRIPTION
Add limited support for handling Intel's TSX (Transactional Synchronization Extensions), specifically Restricted Transactional Memory (RTM) where aborted transactions were not properly handled.

This also makes a minor change which corrects error printing, where a flush was intended (%!) but the % accidentally omitted.  