### PR TITLE
Fix symbol resolution for rust binaries

### DIFF
--- a/magic-trace.opam
+++ b/magic-trace.opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_jane"
   "shell"
   "dune"         {>= "2.0.0"}
-  "owee"         {>= "0.6"}
+  "owee"         {>= "0.8"}
   "re"           {>= "1.8.0"}
   "zstandard"
 ]


### PR DESCRIPTION
Currently symbol resolution on rust binaries returns an address that is 0x1000 above the correct symbol leading to triggers not working.

The current logic seems to assume the symbol value is an offset from the start of the file, but the spec actually states for an executable that this value is a virtual address already: ["In executable and shared object files, st_value holds a virtual address."](https://refspecs.linuxbase.org/elf/gabi4+/ch4.symtab.html#symbol_values)

Most cases can be solved by just picking the first address from the maps file and adding the symbol value to it but there is an edge case where an exotic binary could select a base virtual address that doesn't start at 0x0. This can be detected by reading the program headers and looking at `p_vaddr` for the first `LOAD` segment and subtracting it from the first mapping address that is pulled from /proc/pid/maps.

This PR is blocked by https://github.com/let-def/owee/pull/35 being merged and released.
