### PR TITLE
Allow sharing traces with -share flag

### DIFF
--- a/src/env_vars.ml
+++ b/src/env_vars.ml
@@ -7,6 +7,13 @@ open Async
    files around. *)
 let perfetto_dir = Unix.getenv "MAGIC_TRACE_PERFETTO_DIR"
 
+(* Documentation string for [-share] *)
+let share_doc = Unix.getenv "MAGIC_TRACE_SHARE_DOC"
+
+(* Points to a filesystem path that will be invoked with a trace filename to implement
+   [-share]. *)
+let share_command_filename = Unix.getenv "MAGIC_TRACE_SHARE_COMMAND"
+
 (* Override which [perf] to use. If this isn't set, magic-trace will use whatever's first
    in $PATH. *)
 let perf_path = Option.value ~default:"perf" (Unix.getenv "MAGIC_TRACE_PERF_PATH")

--- a/src/env_vars.mli
+++ b/src/env_vars.mli
@@ -6,6 +6,8 @@ val perf_path : string
 val perf_is_privileged : bool
 val perf_no_kcore : bool
 val perfetto_dir : string option
+val share_doc : string option
+val share_command_filename : string option
 val no_dlfilter : bool
 val fzf_demangle_symbols : bool
 val no_ocaml_exception_debug_info : bool


### PR DESCRIPTION
Re-introduce a PR (original: https://github.com/janestreet/magic-trace/pull/132) to add a `-share` flag when both `MAGIC_TRACE_SHARE_DOC` and `MAGIC_TRACE_SHARE_COMMAND` are provided. It's available as an alternative to `-serve`, and both cannot be provided in the same invocation.

For example, with
```
MAGIC_TRACE_SHARE_DOC=" Share the trace." MAGIC_TRACE_SHARE_COMMAND=/usr/bin/echo magic-trace run -help
```
I see the flag in the CLI help:
```
  [-share]                   . Share the trace.
```
and with a real program to run, the command is invoked, and I see the trace file name echoed into my terminal.