### PR TITLE
Fix race condition on frequently hit breakpoint

### DIFF
--- a/src/breakpoint.ml
+++ b/src/breakpoint.ml
@@ -5,7 +5,6 @@ type t
 external create
   :  pid:Pid.t
   -> addr:int64
-  -> single_hit:bool
   -> (t, int) result
   = "magic_breakpoint_create_stub"
 
@@ -25,10 +24,19 @@ external get_fd : t -> int = "magic_breakpoint_fd_stub"
 external destroy : t -> unit = "magic_breakpoint_destroy_stub"
 external next_hit : t -> Hit.t option = "magic_breakpoint_next_stub"
 
-let breakpoint_fd pid ~addr ~single_hit =
-  match create ~pid ~addr ~single_hit with
+external enable : t -> single_hit:bool -> int or_null = "magic_breakpoint_enable_stub"
+[@@noalloc]
+
+let breakpoint_fd pid ~addr =
+  match create ~pid ~addr with
   | Ok t -> Ok t
   | Error errno -> Errno.to_error errno
+;;
+
+let enable t ~single_hit =
+  match enable t ~single_hit with
+  | Null -> Ok ()
+  | This errno -> Errno.to_error errno
 ;;
 
 let fd t = get_fd t |> Core_unix.File_descr.of_int |> Core_unix.dup

--- a/src/breakpoint.mli
+++ b/src/breakpoint.mli
@@ -3,10 +3,13 @@ open! Core
 type t
 
 (** Uses [perf_event_open] to set a hardware breakpoint at a given address in a process.
-    When that breakpoint is hit the resulting file descriptor will poll as readable.
+    When that breakpoint is hit the resulting file descriptor will poll as readable. The
+    breakpoint starts disabled; call [enable] to arm it. *)
+val breakpoint_fd : Pid.t -> addr:int64 -> t Or_error.t
 
-    If [single_hit] is set the breakpoint will disable itself after being hit once. *)
-val breakpoint_fd : Pid.t -> addr:int64 -> single_hit:bool -> t Or_error.t
+(** Arms the breakpoint. If [single_hit] is set the breakpoint will disable itself after
+    being hit once. *)
+val enable : t -> single_hit:bool -> unit Or_error.t
 
 val destroy : t -> unit
 

--- a/src/breakpoint_stubs.c
+++ b/src/breakpoint_stubs.c
@@ -66,9 +66,8 @@ CAMLprim value magic_breakpoint_fd_stub(value state) {
   return Val_long(Breakpoint_state_val(state)->fd);
 }
 
-CAMLprim value magic_breakpoint_create_stub(value pid, value addr,
-                                            value single_hit) {
-  CAMLparam3(pid, addr, single_hit);
+CAMLprim value magic_breakpoint_create_stub(value pid, value addr) {
+  CAMLparam2(pid, addr);
   CAMLlocal2(wrap, v);
   struct perf_event_attr attr;
 
@@ -83,7 +82,7 @@ CAMLprim value magic_breakpoint_create_stub(value pid, value addr,
                      PERF_SAMPLE_TID;
   attr.exclude_hv = 1;
   attr.exclude_kernel = 1;
-  attr.disabled = Bool_val(single_hit);
+  attr.disabled = 1;
   attr.wakeup_events = 1;
   attr.precise_ip = 2;
   // first and second argument register
@@ -106,12 +105,6 @@ CAMLprim value magic_breakpoint_create_stub(value pid, value addr,
   if (s->mmap == MAP_FAILED)
     goto failed;
 
-  // Makes it so the breakpoint only triggers once before being disabled
-  if (Bool_val(single_hit)) {
-    if (ioctl(s->fd, PERF_EVENT_IOC_REFRESH, 1) < 0)
-      goto failed;
-  }
-
   v = caml_alloc_custom(&breakpoint_state_ops, sizeof(s), 0, 1);
   Breakpoint_state_val(v) = s;
 
@@ -125,6 +118,22 @@ failed:
   wrap = caml_alloc(1, 1); // Error constructor of result
   Field(wrap, 0) = Val_long(errno);
   CAMLreturn(wrap);
+}
+
+CAMLprim value magic_breakpoint_enable_stub(value state, value single_hit) {
+  const struct breakpoint_state *s = Breakpoint_state_val(state);
+  int ret;
+  if (Bool_val(single_hit)) {
+    // Makes it so the breakpoint only triggers once before being disabled
+    ret = ioctl(s->fd, PERF_EVENT_IOC_REFRESH, 1);
+  } else {
+    ret = ioctl(s->fd, PERF_EVENT_IOC_ENABLE, 0);
+  }
+  if (ret < 0) {
+    assert(errno > 0);
+    return Val_long(errno);
+  }
+  return (value)NULL;
 }
 
 struct my_sample {

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -395,7 +395,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
            you can accidentally incur an ~8us interrupt on every call until perf disables
            your breakpoint for exceeding the hit rate limit. *)
         let single_hit = not opts.multi_snapshot in
-        let bp = Breakpoint.breakpoint_fd head_pid ~addr ~single_hit in
+        let bp = Breakpoint.breakpoint_fd head_pid ~addr in
         let bp = Or_error.ok_exn bp in
         let fd =
           Async_unix.Fd.create
@@ -411,7 +411,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
           | None -> ()
         in
         let interrupt = Ivar.read done_ivar in
-        let%map.Deferred res =
+        let monitoring =
           Async_unix.Fd.interruptible_every_ready_to
             fd
             `Read
@@ -419,6 +419,12 @@ module Make_commands (Backend : Backend_intf.S) = struct
             (fun () -> read_evs true)
             ()
         in
+        (* Yield to let the scheduler register the fd with [epoll], then enable
+           the breakpoint. This avoids a race where a single-hit breakpoint
+           fires and disables itself before [epoll] starts monitoring the fd. *)
+        let%bind.Deferred () = Scheduler.yield () in
+        Breakpoint.enable bp ~single_hit |> Or_error.ok_exn;
+        let%map.Deferred res = monitoring in
         (match res with
          | `Interrupted -> Breakpoint.destroy bp
          | `Bad_fd | `Closed | `Unsupported -> failwith "failed to wait on breakpoint")


### PR DESCRIPTION
Specifying a breakpoint `-trigger SYMBOL` on a `SYMBOL` that is very frequently executed would oftentimes result in magic-trace waiting indefinitely, never taking a snapshot. The root-cause was that by default we configure breakpoints as single-hit, but if the first hit occurs between the time where magic-trace creates the breakpoint, and the time where it registers the breakpoint's file descriptor with `epoll`, magic-trace never sees the notification.

This is fixed by only enabling the breakpoint after registering its file descriptor with `epoll`.

Disclaimer: The initial commit was written entirely by Claude Opus 4.6, but I performed manual cleanup.