### PR TITLE
Fix GitHub actions by actually using `opam` lockfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           opam switch set ${{ matrix.ocaml-version }} 2>/dev/null || \
             opam switch create ${{ matrix.ocaml-version }} --repos ox=git+https://github.com/oxcaml/opam-repository.git,default
 
-      - run: opam install ./magic-trace.opam --deps-only --locked
+      - run: opam install . --deps-only --locked
 
       - run: opam install ocamlformat
       - run: opam exec -- dune build @fmt


### PR DESCRIPTION
Apparently if you explicitly provide the path to a `*.opam` file to `opam install`, this takes precedence over `--locked`, and your lockfile is ignored. This is clearly not what we want, and broke our GitHub actions.