### PR TITLE
Fix GitHub actions by pinning dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,9 +87,8 @@ jobs:
           opam switch set ${{ matrix.ocaml-version }} 2>/dev/null || \
             opam switch create ${{ matrix.ocaml-version }} --repos ox=git+https://github.com/oxcaml/opam-repository.git,default
 
-      - run: opam install ./magic-trace.opam --deps-only --locked
+      - run: opam install . --deps-only --locked --with-test
 
-      - run: opam install ocamlformat
       - run: opam exec -- dune build @fmt
 
       - run: opam exec -- make PROFILE=static

--- a/magic-trace.opam
+++ b/magic-trace.opam
@@ -11,6 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"        {>= "4.14"}
+  "ocamlformat"  {with-test}
   "ocaml_intrinsics"
   "async"
   "camlzip"

--- a/magic-trace.opam.locked
+++ b/magic-trace.opam.locked
@@ -58,12 +58,16 @@ depends: [
   "ctypes" {= "0.23.0+ox"}
   "domain-name" {= "0.5.0"}
   "dune" {= "3.21.1"}
+  "dune-build-info" {= "3.21.1" & with-test}
   "dune-configurator" {= "3.21.1"}
+  "either" {= "1.0.0" & with-test}
   "expect_test_helpers_async" {= "v0.18~preview.130.83+317"}
   "expect_test_helpers_core" {= "v0.18~preview.130.83+317"}
   "fieldslib" {= "v0.18~preview.130.83+317"}
+  "fix" {= "20250919" & with-test}
   "flexible_sexp" {= "v0.18~preview.130.83+317"}
   "fmt" {= "0.10.0"}
+  "fpath" {= "0.7.3" & with-test}
   "int_repr" {= "v0.18~preview.130.83+317"}
   "integers" {= "0.7.0"}
   "ipaddr" {= "5.6.2"}
@@ -74,6 +78,11 @@ depends: [
   "logs" {= "0.9.0"}
   "macaddr" {= "5.6.2"}
   "magic-mime" {= "1.3.1"}
+  "menhir" {= "20260209" & with-test}
+  "menhirCST" {= "20260209" & with-test}
+  "menhirGLR" {= "20260209" & with-test}
+  "menhirLib" {= "20260209" & with-test}
+  "menhirSdk" {= "20260209" & with-test}
   "num" {= "1.6"}
   "ocaml" {= "5.2.0"}
   "ocaml-compiler-libs" {= "v0.17.0+ox"}
@@ -81,10 +90,14 @@ depends: [
   "ocaml-options-vanilla" {= "1"}
   "ocaml-syntax-shims" {= "1.0.0"}
   "ocaml-variants" {= "5.2.0+ox"}
+  "ocaml-version" {= "4.0.4" & with-test}
   "ocaml_intrinsics" {= "v0.18~preview.130.83+317"}
   "ocaml_intrinsics_kernel" {= "v0.18~preview.130.83+317"}
   "ocamlbuild" {= "0.15.0+ox"}
   "ocamlfind" {= "1.9.8+ox"}
+  "ocamlformat" {= "0.26.2+ox" & with-test}
+  "ocamlformat-lib" {= "0.26.2+ox" & with-test}
+  "ocp-indent" {= "1.9.0" & with-test}
   "odoc-parser" {= "3.1.0+ox"}
   "owee" {= "0.8"}
   "parsexp" {= "v0.18~preview.130.83+317"}
@@ -166,9 +179,15 @@ depends: [
   "uopt" {= "v0.18~preview.130.83+317"}
   "uri" {= "4.4.0"}
   "uri-sexp" {= "4.4.0"}
+  "uucp" {= "16.0.0" & with-test}
+  "uuseg" {= "16.0.0" & with-test}
   "uutf" {= "1.0.3+ox"}
   "variantslib" {= "v0.18~preview.130.83+317"}
   "zstandard" {= "v0.18~preview.130.83+317"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/janestreet/magic-trace.git"
+pin-depends: [
+  "dune.3.21.1"
+  "https://github.com/ocaml/dune/releases/download/3.21.1/dune-3.21.1.tbz"
+]


### PR DESCRIPTION
I've modified things such that `ocamlformat` is a dev-dependency so that it makes it into the lockfile, because installing it in a separate step seemingly led to `opam` solving to incompatible package versions.