### PR TITLE
Fix stack switching on OpenCilk's runtime

### DIFF
--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -604,18 +604,18 @@ let end_of_thread t (thread_info : _ Thread_info.t) ~time ~is_kernel_address : u
   Thread_info.set_callstack thread_info ~is_kernel_address ~time
 ;;
 
-(* OpenCilk's runtime cheetah (https://github.com/OpenCilk/cheetah) uses
-   longjmp to switch between user and runtime stacks.
+(* OpenCilk's runtime cheetah (https://github.com/OpenCilk/cheetah) uses longjmp to switch
+   between user and runtime stacks.
 
-   To deal with this stack switching, when jumping into the runtime, we need
-   to clear the user's stack frames. The inactive_callstacks mechanism
-   is perfect for keeping track of this stack data. *)
+   To deal with this stack switching, when jumping into the runtime, we need to clear the
+   user's stack frames. The inactive_callstacks mechanism is perfect for keeping track of
+   this stack data. *)
 module OpenCilk_hacks : sig
   val call_handle_stack_switch
-    : 'a inner
+    :  'a inner
     -> 'a Thread_info.t
     -> time:Mapped_time.t
-    -> location: Event.Location.t
+    -> location:Event.Location.t
     -> unit
 end = struct
   let ret = ret_without_checking_for_go_hacks
@@ -623,24 +623,23 @@ end = struct
   let switch_to_user_code t (thread_info : _ Thread_info.t) ~time =
     (* Pop the sysdep_longjmp_to_sf frame *)
     ret t thread_info ~time;
-    (* The next stack frame is either __cilkrts_sync or longjmp_to_user_code.
-       In either case, we want to pop this frame as well. *)
+    (* The next stack frame is either __cilkrts_sync or longjmp_to_user_code. In either
+       case, we want to pop this frame as well. *)
     match Callstack.top thread_info.callstack with
     | Some { symbol = From_perf symbol; _ } ->
       (match symbol with
-      | "longjmp_to_user_code(__cilkrts_worker*, Closure*)" ->
-        ret t thread_info ~time;
-        Stack.push thread_info.inactive_callstacks thread_info.callstack;
-        thread_info.callstack <- Callstack.create ~create_time:time
-      | "__cilkrts_sync" ->
-        ret t thread_info ~time
-      | _ -> Printf.printf "OpenCilk_hacks: Unexpected symbol %s\n" symbol)
+       | "longjmp_to_user_code(__cilkrts_worker*, Closure*)" ->
+         ret t thread_info ~time;
+         Stack.push thread_info.inactive_callstacks thread_info.callstack;
+         thread_info.callstack <- Callstack.create ~create_time:time
+       | "__cilkrts_sync" -> ret t thread_info ~time
+       | _ -> Printf.printf "OpenCilk_hacks: Unexpected symbol %s\n" symbol)
     | _ -> Printf.printf "OpenCilk_hacks: Unexpected symbol [unknown]"
   ;;
 
   let switch_to_runtime t (thread_info : _ Thread_info.t) ~time =
-    (* Even though we want to pop the longjmp_to_runtime frame, we're clearing
-       the entire user stack anyways, so no point in manually popping. *)
+    (* Even though we want to pop the longjmp_to_runtime frame, we're clearing the entire
+       user stack anyways, so no point in manually popping. *)
     clear_callstack t thread_info ~time;
     match Stack.pop thread_info.inactive_callstacks with
     | Some callstack -> thread_info.callstack <- callstack
@@ -651,9 +650,9 @@ end = struct
     let call_symbol = Event.Location.symbol location in
     match call_symbol with
     | From_perf "sysdep_longjmp_to_sf(__cilkrts_stack_frame*)" ->
-      switch_to_user_code t thread_info ~time;
+      switch_to_user_code t thread_info ~time
     | From_perf "longjmp_to_runtime(__cilkrts_worker*)" ->
-      switch_to_runtime t thread_info ~time;
+      switch_to_runtime t thread_info ~time
     | _ -> ()
   ;;
 end

--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -558,12 +558,6 @@ let create_thread t event =
   }
 ;;
 
-let call t thread_info ~time ~location =
-  let ev = Pending_event.create_call location ~from_untraced:false in
-  add_event t thread_info time ev;
-  Callstack.push thread_info.callstack location
-;;
-
 let ret_without_checking_for_go_hacks t (thread_info : _ Thread_info.t) ~time =
   match Callstack.pop thread_info.callstack with
   | Some { symbol; _ } -> add_event t thread_info time { symbol; kind = Ret }
@@ -608,6 +602,34 @@ let end_of_thread t (thread_info : _ Thread_info.t) ~time ~is_kernel_address : u
   flush t ~to_time thread_info;
   thread_info.last_decode_error_time <- time;
   Thread_info.set_callstack thread_info ~is_kernel_address ~time
+;;
+
+module Cilk_hacks : sig
+  val call_clear_if_scheduler
+    : 'a inner
+    -> 'a Thread_info.t
+    -> time:Mapped_time.t
+    -> location: Event.Location.t
+    -> unit
+end = struct
+  let is_cilk_scheduler (symbol : Symbol.t) =
+    match symbol with
+    | From_perf "worker_scheduler(__cilkrts_worker*, history_t*)" -> true
+    | _ -> false
+  ;;
+
+  let call_clear_if_scheduler t thread_info ~time ~location =
+    let call_symbol = Event.Location.symbol location in
+    if is_cilk_scheduler call_symbol
+      then clear_callstack t thread_info ~time;
+  ;;
+end
+
+let call t thread_info ~time ~location =
+  Cilk_hacks.call_clear_if_scheduler t thread_info ~time ~location;
+  let ev = Pending_event.create_call location ~from_untraced:false in
+  add_event t thread_info time ev;
+  Callstack.push thread_info.callstack location
 ;;
 
 (* Go (the programming language) has coroutines known as goroutines. The function [gogo] jumps

--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -620,7 +620,7 @@ module OpenCilk_hacks : sig
 end = struct
   let ret = ret_without_checking_for_go_hacks
 
-  let call_switch_to_user_code t (thread_info : _ Thread_info.t) ~time =
+  let switch_to_user_code t (thread_info : _ Thread_info.t) ~time =
     (* Pop the sysdep_longjmp_to_sf frame *)
     ret t thread_info ~time;
     (* The next stack frame is either __cilkrts_sync or longjmp_to_user_code.
@@ -634,11 +634,11 @@ end = struct
         thread_info.callstack <- Callstack.create ~create_time:time
       | "__cilkrts_sync" ->
         ret t thread_info ~time
-      | _ -> ())
-    | _ ->()
+      | _ -> Printf.printf "OpenCilk_hacks: Unexpected symbol %s\n" symbol)
+    | _ -> Printf.printf "OpenCilk_hacks: Unexpected symbol [unknown]"
   ;;
 
-  let call_switch_to_runtime t (thread_info : _ Thread_info.t) ~time =
+  let switch_to_runtime t (thread_info : _ Thread_info.t) ~time =
     (* Even though we want to pop the longjmp_to_runtime frame, we're clearing
        the entire user stack anyways, so no point in manually popping. *)
     clear_callstack t thread_info ~time;
@@ -651,9 +651,9 @@ end = struct
     let call_symbol = Event.Location.symbol location in
     match call_symbol with
     | From_perf "sysdep_longjmp_to_sf(__cilkrts_stack_frame*)" ->
-      call_switch_to_user_code t thread_info ~time;
+      switch_to_user_code t thread_info ~time;
     | From_perf "longjmp_to_runtime(__cilkrts_worker*)" ->
-      call_switch_to_runtime t thread_info ~time;
+      switch_to_runtime t thread_info ~time;
     | _ -> ()
   ;;
 end

--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -604,7 +604,13 @@ let end_of_thread t (thread_info : _ Thread_info.t) ~time ~is_kernel_address : u
   Thread_info.set_callstack thread_info ~is_kernel_address ~time
 ;;
 
-module Cilk_hacks : sig
+(* OpenCilk's runtime cheetah (https://github.com/OpenCilk/cheetah) uses
+   longjmp to switch between user and runtime stacks.
+
+   To deal with this stack switching, when jumping into the runtime, we need
+   to clear the user's stack frames. The inactive_callstacks mechanism
+   is perfect for keeping track of this stack data. *)
+module OpenCilk_hacks : sig
   val call_handle_stack_switch
     : 'a inner
     -> 'a Thread_info.t
@@ -615,13 +621,26 @@ end = struct
   let ret = ret_without_checking_for_go_hacks
 
   let call_switch_to_user_code t (thread_info : _ Thread_info.t) ~time =
+    (* Pop the sysdep_longjmp_to_sf frame *)
     ret t thread_info ~time;
-    Stack.push thread_info.inactive_callstacks thread_info.callstack;
-    thread_info.callstack <- Callstack.create ~create_time:time
+    (* The next stack frame is either __cilkrts_sync or longjmp_to_user_code.
+       In either case, we want to pop this frame as well. *)
+    match Callstack.top thread_info.callstack with
+    | Some { symbol = From_perf symbol; _ } ->
+      (match symbol with
+      | "longjmp_to_user_code(__cilkrts_worker*, Closure*)" ->
+        ret t thread_info ~time;
+        Stack.push thread_info.inactive_callstacks thread_info.callstack;
+        thread_info.callstack <- Callstack.create ~create_time:time
+      | "__cilkrts_sync" ->
+        ret t thread_info ~time
+      | _ -> ())
+    | _ ->()
   ;;
 
   let call_switch_to_runtime t (thread_info : _ Thread_info.t) ~time =
-    ret t thread_info ~time;
+    (* Even though we want to pop the longjmp_to_runtime frame, we're clearing
+       the entire user stack anyways, so no point in manually popping. *)
     clear_callstack t thread_info ~time;
     match Stack.pop thread_info.inactive_callstacks with
     | Some callstack -> thread_info.callstack <- callstack
@@ -631,7 +650,7 @@ end = struct
   let call_handle_stack_switch t thread_info ~time ~location =
     let call_symbol = Event.Location.symbol location in
     match call_symbol with
-    | From_perf "longjmp_to_user_code(__cilkrts_worker*, Closure*)" ->
+    | From_perf "sysdep_longjmp_to_sf(__cilkrts_stack_frame*)" ->
       call_switch_to_user_code t thread_info ~time;
     | From_perf "longjmp_to_runtime(__cilkrts_worker*)" ->
       call_switch_to_runtime t thread_info ~time;
@@ -643,7 +662,7 @@ let call t thread_info ~time ~location =
   let ev = Pending_event.create_call location ~from_untraced:false in
   add_event t thread_info time ev;
   Callstack.push thread_info.callstack location;
-  Cilk_hacks.call_handle_stack_switch t thread_info ~time ~location
+  OpenCilk_hacks.call_handle_stack_switch t thread_info ~time ~location
 ;;
 
 (* Go (the programming language) has coroutines known as goroutines. The function [gogo] jumps

--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -605,31 +605,45 @@ let end_of_thread t (thread_info : _ Thread_info.t) ~time ~is_kernel_address : u
 ;;
 
 module Cilk_hacks : sig
-  val call_clear_if_scheduler
+  val call_handle_stack_switch
     : 'a inner
     -> 'a Thread_info.t
     -> time:Mapped_time.t
     -> location: Event.Location.t
     -> unit
 end = struct
-  let is_cilk_scheduler (symbol : Symbol.t) =
-    match symbol with
-    | From_perf "worker_scheduler(__cilkrts_worker*, history_t*)" -> true
-    | _ -> false
+  let ret = ret_without_checking_for_go_hacks
+
+  let call_switch_to_user_code t (thread_info : _ Thread_info.t) ~time =
+    ret t thread_info ~time;
+    Stack.push thread_info.inactive_callstacks thread_info.callstack;
+    thread_info.callstack <- Callstack.create ~create_time:time
   ;;
 
-  let call_clear_if_scheduler t thread_info ~time ~location =
+  let call_switch_to_runtime t (thread_info : _ Thread_info.t) ~time =
+    ret t thread_info ~time;
+    clear_callstack t thread_info ~time;
+    match Stack.pop thread_info.inactive_callstacks with
+    | Some callstack -> thread_info.callstack <- callstack
+    | None -> thread_info.callstack <- Callstack.create ~create_time:time
+  ;;
+
+  let call_handle_stack_switch t thread_info ~time ~location =
     let call_symbol = Event.Location.symbol location in
-    if is_cilk_scheduler call_symbol
-      then clear_callstack t thread_info ~time;
+    match call_symbol with
+    | From_perf "longjmp_to_user_code(__cilkrts_worker*, Closure*)" ->
+      call_switch_to_user_code t thread_info ~time;
+    | From_perf "longjmp_to_runtime(__cilkrts_worker*)" ->
+      call_switch_to_runtime t thread_info ~time;
+    | _ -> ()
   ;;
 end
 
 let call t thread_info ~time ~location =
-  Cilk_hacks.call_clear_if_scheduler t thread_info ~time ~location;
   let ev = Pending_event.create_call location ~from_untraced:false in
   add_event t thread_info time ev;
-  Callstack.push thread_info.callstack location
+  Callstack.push thread_info.callstack location;
+  Cilk_hacks.call_handle_stack_switch t thread_info ~time ~location
 ;;
 
 (* Go (the programming language) has coroutines known as goroutines. The function [gogo] jumps


### PR DESCRIPTION
OpenCilk's work stealing scheduler [cheetah](https://github.com/OpenCilk/cheetah) uses longjmp to switch between user and runtime code. This causes the stackframes to stairstep downwards, as expected from the FAQ.

<img width="1155" height="718" alt="image" src="https://github.com/user-attachments/assets/273d416a-e44c-49f3-a36b-8b801a501f71" />

So, I've "added some explicit code in magic-trace for [OpenCilk]".

In particular, upon jumping to user code, the runtime's stack is put into an inactive stack, which is then restored when jumping back to the user code.

The main two functions in cheetah that call longjmp are `longjmp_to_runtime` and `sysdep_longjmp_to_sf`.
`sysdep_longjmp_to_sf` is called from two different places, `longjmp_to_user_code` or `__cilkrts_sync`.
This means an extra frame needs to be popped when `sysdep_longjmp_to_sf` is called, and we should only put the runtime stack into an inactive stack when we see `longjmp_to_user_code`.

This is my first time writing OCaml, and honestly I was fumbling around copying and adapting other parts of the codebase to coerce things to work. But it seems like things work well enough that it's now much easier to tell if Cilk workers are failing to find work.

<img width="1164" height="690" alt="image" src="https://github.com/user-attachments/assets/3455fe92-028d-4c38-8065-7940d4f39590" />