### PR TITLE
Update OCaml symbol name resolution

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -15,7 +15,7 @@
  (action
   (progn
    (bash
-    "clang++ -std=c++20 -Wall -Wextra -Werror -Wno-unused-parameter -DCAML_NAME_SPACE -I %{ocaml_where} $(llvm-config --cxxflags) -O3 -march=broadwell -mtune=skylake -ffunction-sections -c llvm_symbolizer_stubs.cpp")
+    "clang++ -Wall -Wextra -Werror -Wno-unused-parameter -DCAML_NAME_SPACE -I %{ocaml_where} $(llvm-config --cxxflags) -std=c++20 -O3 -march=broadwell -mtune=skylake -ffunction-sections -c llvm_symbolizer_stubs.cpp")
    (bash
     "ld.lld llvm_symbolizer_stubs.o --gc-sections -static -r -plugin-opt=mcpu=broadwell -plugin-opt=O3 --hash-style=gnu --build-id --start-lib $(llvm-config --link-static --libfiles Symbolize) --end-lib -o libLLVM.o")
    (run llvm-strip --strip-debug libLLVM.o)

--- a/src/llvm_symbolizer_stubs.cpp
+++ b/src/llvm_symbolizer_stubs.cpp
@@ -1,26 +1,29 @@
 #include <cstdint>
 #include <cstring>
+#include <cstddef>
+#include <string_view>
 
 #include "caml/alloc.h"
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
+#include "llvm/DebugInfo/Symbolize/SymbolizableModule.h"
 #include "llvm/DebugInfo/Symbolize/Symbolize.h"
 
 namespace {
 value ocaml_string_of_cpp_string(std::string_view string) {
   return caml_alloc_initialized_string(string.length(), string.data());
 }
+
+// Matches `caml[A-Z]`, the prefix for an OCaml mangled name.
+bool is_ocaml_mangled(std::string_view name) noexcept {
+  return name.starts_with("caml") && name.size() > 4 && name[4] >= 'A' && name[4] <= 'Z';
+}
 } // namespace
 
 extern "C" {
 CAMLprim llvm::symbolize::LLVMSymbolizer *__attribute__((used, retain))
 magic_trace_llvm_symbolizer_create() {
-  llvm::symbolize::LLVMSymbolizer::Options options{};
-  // We need this for now to work around the fact the OCaml compiler inverts
-  // `DW_AT_name` and `DW_AT_linkage_name`, which breaks LLVM's assumptions when
-  // it tries to use the symbol table.
-  options.UseSymbolTable = false;
-  return new llvm::symbolize::LLVMSymbolizer(options);
+  return new llvm::symbolize::LLVMSymbolizer();
 }
 
 CAMLprim void __attribute__((used, retain))
@@ -32,7 +35,7 @@ CAMLprim value __attribute__((used, retain))
 magic_trace_llvm_symbolize_address(llvm::symbolize::LLVMSymbolizer *symbolizer,
                                    value v_executable_file, uintptr_t address) {
   CAMLparam1(v_executable_file);
-  CAMLlocal2(inlined_frames, demangled_name);
+  CAMLlocal2(inlined_frames, symbol_name);
   std::string_view executable_file{String_val(v_executable_file),
                                    caml_string_length(v_executable_file)};
   llvm::object::SectionedAddress sectioned_address{
@@ -46,6 +49,35 @@ magic_trace_llvm_symbolize_address(llvm::symbolize::LLVMSymbolizer *symbolizer,
   if (num_frames == 0) {
     CAMLreturn((value)NULL);
   }
+
+  // LLVM gives us the (demangled) LinkageName, but it can't demangle OCaml
+  // symbols. We could demangle ourselves, but the name the compiler emits
+  // under [DW_AT_name] is considerably more readable, so we use that instead.
+  const llvm::DIInliningInfo *short_frames = nullptr;
+  llvm::DIInliningInfo short_result;
+  bool needs_short_names = false;
+  for (uint32_t i = 0; i < num_frames; i++) {
+    if (is_ocaml_mangled(frames.getFrame(i).FunctionName)) {
+      needs_short_names = true;
+      break;
+    }
+  }
+  if (needs_short_names) {
+    if (auto module = symbolizer->getOrCreateModuleInfo(executable_file)) {
+      if (llvm::symbolize::SymbolizableModule *info = *module) {
+        short_result = info->symbolizeInlinedCode(
+            sectioned_address,
+            llvm::DILineInfoSpecifier(
+                llvm::DILineInfoSpecifier::FileLineInfoKind::AbsoluteFilePath,
+                llvm::DINameKind::ShortName),
+            /*UseSymbolTable=*/true);
+        short_frames = &short_result;
+      }
+    } else {
+      llvm::consumeError(module.takeError());
+    }
+  }
+
   if (num_frames <= Max_young_wosize) [[likely]] {
     inlined_frames = caml_alloc_small(/*wosize=*/num_frames, /*tag=*/0);
   } else {
@@ -54,8 +86,13 @@ magic_trace_llvm_symbolize_address(llvm::symbolize::LLVMSymbolizer *symbolizer,
   memset((uint8_t *)inlined_frames, 0xFF, Bsize_wsize(num_frames));
   for (uint32_t i = 0; i < num_frames; i++) {
     const auto &frame = frames.getFrame(i);
-    demangled_name = ocaml_string_of_cpp_string(frame.FunctionName);
-    caml_modify(&Field(inlined_frames, num_frames - 1 - i), demangled_name);
+    std::string_view name = frame.FunctionName;
+    if (short_frames != nullptr && is_ocaml_mangled(frame.FunctionName) &&
+        i < short_frames->getNumberOfFrames()) {
+      name = short_frames->getFrame(i).FunctionName;
+    }
+    symbol_name = ocaml_string_of_cpp_string(name);
+    caml_modify(&Field(inlined_frames, num_frames - 1 - i), symbol_name);
   }
   CAMLreturn(inlined_frames);
 }


### PR DESCRIPTION
Now that [PR 5976](https://github.com/oxcaml/oxcaml/pull/5976) has made it into the latest OxCaml compiler release, we need to change the way we resolve OCaml symbol names. We continue to use the compiler-emitted "pretty" name as before; the updates here just handle the fact that has been moved from `DW_AT_linkage_name` to `DW_AT_name`.