### PR TITLE
Parse uppercase flags in perf CBR events

### DIFF
--- a/src/perf_decode.ml
+++ b/src/perf_decode.ml
@@ -26,7 +26,8 @@ let perf_branches_event_re =
 ;;
 
 let perf_cbr_event_re =
-  Re.Perl.re {|^ *([a-z )(]*)? +cbr: +([0-9]+ +freq: +([0-9]+) MHz)?(.*)$|} |> Re.compile
+  Re.Perl.re {|^ *([a-zA-Z )(]*)? +cbr: +([0-9]+ +freq: +([0-9]+) MHz)?(.*)$|}
+  |> Re.compile
 ;;
 
 let trace_error_re =
@@ -646,6 +647,18 @@ module%test _ = struct
         ((Ok
           ((thread ((pid (21302)) (tid (21302)))) (time 22h51m58.700445693s)
            (data (Power (freq 4500)))))) |}]
+  ;;
+
+  let%expect_test "cbr event with uppercase flag" =
+    check
+      "377433/377433 1693789.232275122:          1                                  \
+       cbr:   D                      cbr: 36 freq: 3629 MHz (450%)                   \
+       0     6143f240a145 main+0x1c (/root/foo)";
+    [%expect
+      {|
+        ((Ok
+          ((thread ((pid (377433)) (tid (377433)))) (time 19d14h29m49.232275122s)
+           (data (Power (freq 3629)))))) |}]
   ;;
 
   (* Expected [None] because we ignore these events currently. *)


### PR DESCRIPTION
## Summary
- accept uppercase letters in the ignored annotation prefix of perf CBR events
- add a regression using the Ubuntu 24.04 `perf script` line from the issue

## Why
Newer perf output can include an uppercase `D` marker before the CBR payload. The parser only accepted lowercase annotation text there, so `Re.exec` raised `Not_found` before the frequency event could be decoded.

## Validation
- `git diff --check`
- exercised the widened CBR pattern against the reported line and confirmed it extracts `3629` MHz
- added expect coverage for the reported parser path

Fixes #324