### PR TITLE
Open attached executables through procfs

### DIFF
--- a/src/elf.ml
+++ b/src/elf.ml
@@ -302,7 +302,14 @@ let all_file_selections t symbol =
 ;;
 
 let selection_stop_info t pid selection =
-  let filename = Filename_unix.realpath t.filename in
+  (* Keep procfs executable symlinks openable across mount namespaces, but compare
+     against the target path exposed in [/proc/$pid/maps]. *)
+  let filename =
+    if String.is_prefix t.filename ~prefix:"/proc/"
+       && String.is_suffix t.filename ~suffix:"/exe"
+    then Core_unix.readlink t.filename
+    else Filename_unix.realpath t.filename
+  in
   let compute_addr addr =
     if t.statically_mappable
     then addr

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -747,7 +747,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
               trigger can be passed currently. *)
            let executable =
              List.hd_exn pids
-             |> fun pid -> Core_unix.readlink [%string "/proc/%{pid#Pid}/exe"]
+             |> fun pid -> [%string "/proc/%{pid#Pid}/exe"]
            in
            record_opt_fn ~executable ~f:(fun opts ->
              let { Record_opts.executable; when_to_snapshot; collection_mode; _ } =


### PR DESCRIPTION
## Summary
- keep `/proc/<pid>/exe` intact while loading an attached process executable
- use the procfs symlink target only when matching the executable name reported by `/proc/<pid>/maps`
- preserve the existing `realpath` behavior for ordinary executable paths

Fixes #307.

## Why both paths are needed
For a process in another mount namespace, `/proc/<pid>/exe` remains openable from the host even when its symlink target, such as `/app/server`, is not present in the host filesystem. Concretely, `readlink("/proc/123/exe")` can return `/app/server` while `open("/app/server")` fails on the host and `open("/proc/123/exe")` succeeds. The maps file still reports `/app/server`, so stop-filter address calculation needs the `readlink` result for its pathname comparison while ELF loading needs the procfs path itself.

## Validation
- `git diff --check`
- reviewed both executable consumers: ELF loading now receives the procfs path for attach mode, and map-name comparison resolves only procfs executable symlinks with `readlink`