### PR TITLE
Add Intel PT AUX trace range support

### DIFF
--- a/src/aux_trace_range.ml
+++ b/src/aux_trace_range.ml
@@ -1,0 +1,23 @@
+open! Core
+
+type t =
+  { start_symbol : Symbol_selection.t
+  ; stop_symbol : Symbol_selection.t
+  }
+
+let param =
+  let open Command.Param in
+  flag
+    "-aux-range"
+    (optional
+       (Arg_type.create (fun s ->
+          let start_symbol, stop_symbol =
+            Sexp.of_string s
+            |> Tuple2.t_of_sexp String.t_of_sexp String.t_of_sexp
+            |> Tuple2.map ~f:Symbol_selection.of_command_string
+          in
+          { start_symbol; stop_symbol })))
+    ~doc:
+      "_ Record Intel PT only between START and STOP. Syntax: -aux-range \"(<START> \
+       <STOP>)\"."
+;;

--- a/src/aux_trace_range.mli
+++ b/src/aux_trace_range.mli
@@ -1,0 +1,8 @@
+open! Core
+
+type t =
+  { start_symbol : Symbol_selection.t
+  ; stop_symbol : Symbol_selection.t
+  }
+
+val param : t option Command.Param.t

--- a/src/collection_mode.ml
+++ b/src/collection_mode.ml
@@ -1,5 +1,39 @@
 open! Core
 
+module Aux_action = struct
+  type t =
+    | Start_paused
+    | Resume
+    | Pause
+  [@@deriving compare, sexp]
+
+  let to_string = function
+    | Start_paused -> "start-paused"
+    | Resume -> "resume"
+    | Pause -> "pause"
+  ;;
+
+  let add_to_perf_config t config =
+    let aux_action = to_string t in
+    if String.is_empty config
+    then [%string "aux-action=%{aux_action}"]
+    else [%string "%{config},aux-action=%{aux_action}"]
+  ;;
+end
+
+module Aux_control_event = struct
+  type t =
+    { address : int64
+    ; action : Aux_action.t
+    }
+  [@@deriving sexp]
+
+  let to_perf_event { address; action } =
+    let action = Aux_action.to_string action in
+    Printf.sprintf "mem:0x%Lx:x/aux-action=%s/" address action
+  ;;
+end
+
 module Event = struct
   module Name = struct
     type t =
@@ -49,12 +83,42 @@ module Event = struct
 end
 
 type t =
-  | Intel_processor_trace of { extra_events : Event.t list }
+  | Intel_processor_trace of
+      { extra_events : Event.t list
+      ; aux_action : Aux_action.t option
+      ; aux_control_events : Aux_control_event.t list
+      }
   | Stacktrace_sampling of { extra_events : Event.t list }
 
 let extra_events = function
-  | Intel_processor_trace { extra_events } | Stacktrace_sampling { extra_events } ->
+  | Intel_processor_trace { extra_events; _ } | Stacktrace_sampling { extra_events } ->
     extra_events
+;;
+
+let aux_action = function
+  | Intel_processor_trace { aux_action; _ } -> aux_action
+  | Stacktrace_sampling _ -> None
+;;
+
+let aux_control_events = function
+  | Intel_processor_trace { aux_control_events; _ } -> aux_control_events
+  | Stacktrace_sampling _ -> []
+;;
+
+let with_aux_control t ~start_address ~stop_address =
+  match t with
+  | Intel_processor_trace { extra_events; _ } ->
+    Ok
+      (Intel_processor_trace
+         { extra_events
+         ; aux_action = Some Aux_action.Start_paused
+         ; aux_control_events =
+             [ { Aux_control_event.address = start_address; action = Aux_action.Resume }
+             ; { Aux_control_event.address = stop_address; action = Aux_action.Pause }
+             ]
+         })
+  | Stacktrace_sampling _ ->
+    Or_error.error_string "AUX trace ranges require Intel Processor Trace"
 ;;
 
 let select_collection_mode ~extra_events ~use_sampling =
@@ -62,7 +126,8 @@ let select_collection_mode ~extra_events ~use_sampling =
   | true -> Stacktrace_sampling { extra_events }
   | false ->
     (match Core_unix.access "/sys/bus/event_source/devices/intel_pt" [ `Exists ] with
-     | Ok () -> Intel_processor_trace { extra_events }
+     | Ok () ->
+       Intel_processor_trace { extra_events; aux_action = None; aux_control_events = [] }
      | Error _ ->
        Core.eprintf
          "Intel PT support not found. magic-trace will continue and use sampling instead.\n";

--- a/src/collection_mode.mli
+++ b/src/collection_mode.mli
@@ -1,5 +1,26 @@
 open! Core
 
+module Aux_action : sig
+  type t =
+    | Start_paused
+    | Resume
+    | Pause
+  [@@deriving compare, sexp]
+
+  val to_string : t -> string
+  val add_to_perf_config : t -> string -> string
+end
+
+module Aux_control_event : sig
+  type t =
+    { address : int64
+    ; action : Aux_action.t
+    }
+  [@@deriving sexp]
+
+  val to_perf_event : t -> string
+end
+
 module Event : sig
   module Name : sig
     type t =
@@ -33,8 +54,15 @@ module Event : sig
 end
 
 type t =
-  | Intel_processor_trace of { extra_events : Event.t list }
+  | Intel_processor_trace of
+      { extra_events : Event.t list
+      ; aux_action : Aux_action.t option
+      ; aux_control_events : Aux_control_event.t list
+      }
   | Stacktrace_sampling of { extra_events : Event.t list }
 
+val with_aux_control : t -> start_address:int64 -> stop_address:int64 -> t Or_error.t
 val extra_events : t -> Event.t list
+val aux_action : t -> Aux_action.t option
+val aux_control_events : t -> Aux_control_event.t list
 val param : t Command.Param.t

--- a/src/perf_tool_backend.ml
+++ b/src/perf_tool_backend.ml
@@ -317,6 +317,12 @@ module Recording = struct
         let%map.Or_error intel_pt_config =
           perf_intel_pt_config_of_timer_resolution ~capabilities timer_resolution
         in
+        let intel_pt_config =
+          match Collection_mode.aux_action collection_mode with
+          | None -> intel_pt_config
+          | Some aux_action ->
+            Collection_mode.Aux_action.add_to_perf_config aux_action intel_pt_config
+        in
         [%string "intel_pt/%{intel_pt_config}/%{selector}"]
       | Stacktrace_sampling _ ->
         let%map.Or_error cycles_config =
@@ -324,10 +330,15 @@ module Recording = struct
         in
         [%string "cycles/%{cycles_config}/%{selector}"]
     in
+    let aux_control_events =
+      Collection_mode.aux_control_events collection_mode
+      |> List.map ~f:Collection_mode.Aux_control_event.to_perf_event
+    in
     let extra_events =
       perf_config_of_extra_events ~selector (Collection_mode.extra_events collection_mode)
     in
-    let arg_string = String.concat ~sep:"," (primary_event :: extra_events) in
+    let events = (primary_event :: aux_control_events) @ extra_events in
+    let arg_string = String.concat ~sep:"," events in
     [ [%string "--event=%{arg_string}"] ]
   ;;
 
@@ -566,6 +577,10 @@ module Recording = struct
     | Ok res -> perf_exit_to_or_error res
     | Error _exn -> Ok ()
   ;;
+end
+
+module For_testing = struct
+  let perf_args_of_collection_mode = Recording.perf_args_of_collection_mode
 end
 
 module Decode_opts = struct

--- a/src/perf_tool_backend.mli
+++ b/src/perf_tool_backend.mli
@@ -1,2 +1,11 @@
 (** A backend that uses the [perf] command line tool for recording and decoding *)
 include Backend_intf.S
+
+module For_testing : sig
+  val perf_args_of_collection_mode
+    :  capabilities:Perf_capabilities.t
+    -> timer_resolution:Timer_resolution.t
+    -> trace_scope:Trace_scope.t
+    -> Collection_mode.t
+    -> string list Or_error.t
+end

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -318,6 +318,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
       ; multi_snapshot : bool
       ; when_to_snapshot : When_to_snapshot.t
       ; trace_filter : Trace_filter.Unevaluated.t option
+      ; aux_trace_range : Aux_trace_range.t option
       ; record_dir : string
       ; executable : string
       ; trace_scope : Trace_scope.t
@@ -370,6 +371,46 @@ module Make_commands (Backend : Backend_intf.S) = struct
            in
            let snap_loc = Elf.selection_stop_info elf head_pid snap_sym in
            return (Some snap_loc))
+    in
+    let%bind collection_mode =
+      match opts.aux_trace_range with
+      | None -> return collection_mode
+      | Some { Aux_trace_range.start_symbol; stop_symbol } ->
+        (match elf with
+         | None ->
+           Deferred.Or_error.error_string
+             "Cannot use -aux-range because magic-trace could not load the executable's \
+              symbol table"
+         | Some elf ->
+           let resolve ~header symbol_selection =
+             let%bind symbol_name =
+               Symbol_selection.evaluate
+                 ~supports_fzf
+                 ~elf:(Some elf)
+                 ~header
+                 symbol_selection
+             in
+             let%map selection =
+               Deferred.return
+                 (Result.of_option
+                    (Elf.find_selection elf symbol_name)
+                    ~error:
+                      (Error.of_string
+                         [%string "AUX range symbol not found: %{symbol_name}"]))
+             in
+             Elf.selection_stop_info elf head_pid selection
+           in
+           let%bind start_info =
+             resolve ~header:"AUX trace range start symbol" start_symbol
+           in
+           let%bind stop_info =
+             resolve ~header:"AUX trace range stop symbol" stop_symbol
+           in
+           Deferred.return
+             (Collection_mode.with_aux_control
+                collection_mode
+                ~start_address:start_info.addr
+                ~stop_address:stop_info.addr))
     in
     let%map.Deferred.Or_error recording, recording_data =
       Backend.Recording.attach_and_record
@@ -555,6 +596,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
     let%map_open.Command record_dir = record_dir_flag optional
     and when_to_snapshot = When_to_snapshot.param
     and trace_filter = Trace_filter.param
+    and aux_trace_range = Aux_trace_range.param
     and multi_snapshot =
       flag
         "-multi-snapshot"
@@ -589,6 +631,7 @@ module Make_commands (Backend : Backend_intf.S) = struct
             ; multi_snapshot
             ; when_to_snapshot
             ; trace_filter
+            ; aux_trace_range
             ; record_dir
             ; executable
             ; trace_scope

--- a/test/test.ml
+++ b/test/test.ml
@@ -177,7 +177,9 @@ let dump_using_file ?range_symbols events =
       ~hits:[]
       ~events:[ events ]
       ~close_result
-      ~collection_mode:(Intel_processor_trace { extra_events = [] })
+      ~collection_mode:
+        (Intel_processor_trace
+           { extra_events = []; aux_action = None; aux_control_events = [] })
       ()
   in
   ok_exn or_error;
@@ -849,4 +851,58 @@ let%expect_test "get debug information from ELF" =
   Expect_test_helpers_base.require_equal (module Int) raise_after_col 22;
   [%expect {| |}];
   return ()
+;;
+
+let%expect_test "aux actions are encoded in perf event configs" =
+  let module Aux_action = Magic_trace_lib.Collection_mode.Aux_action in
+  let print action config =
+    Aux_action.add_to_perf_config action config |> print_endline
+  in
+  print Start_paused "";
+  print Start_paused "cyc=1";
+  print Resume "cyc=1";
+  print Pause "cyc=1";
+  [%expect
+    {|
+    aux-action=start-paused
+    cyc=1,aux-action=start-paused
+    cyc=1,aux-action=resume
+    cyc=1,aux-action=pause |}]
+;;
+
+let%expect_test "aux control events are encoded as perf breakpoints" =
+  let module Aux_control_event = Magic_trace_lib.Collection_mode.Aux_control_event in
+  let module Aux_action = Magic_trace_lib.Collection_mode.Aux_action in
+  let print action address =
+    Aux_control_event.to_perf_event { address; action } |> print_endline
+  in
+  print Aux_action.Resume 0x1234L;
+  print Aux_action.Pause 0x5678L;
+  [%expect {|
+    mem:0x1234:x/aux-action=resume/
+    mem:0x5678:x/aux-action=pause/ |}]
+;;
+
+let%expect_test "perf args include AUX-gated Intel PT events" =
+  let open Magic_trace_lib in
+  let collection_mode =
+    Collection_mode.Intel_processor_trace
+      { extra_events = []
+      ; aux_action = Some Collection_mode.Aux_action.Start_paused
+      ; aux_control_events =
+          [ { address = 0x1234L; action = Collection_mode.Aux_action.Resume }
+          ; { address = 0x5678L; action = Collection_mode.Aux_action.Pause }
+          ]
+      }
+  in
+  Perf_tool_backend.For_testing.perf_args_of_collection_mode
+    ~capabilities:Perf_capabilities.empty
+    ~timer_resolution:Timer_resolution.Low
+    ~trace_scope:Trace_scope.Userspace
+    collection_mode
+  |> Or_error.ok_exn
+  |> List.iter ~f:print_endline;
+  [%expect
+    {|
+    --event=intel_pt/aux-action=start-paused/u,mem:0x1234:x/aux-action=resume/,mem:0x5678:x/aux-action=pause/ |}]
 ;;


### PR DESCRIPTION
## Summary

Add record-time Intel PT range gating using perf AUX actions.

This introduces `-aux-range "(START STOP)"`, which resolves the selected symbols to runtime addresses and configures perf so that:

- Intel PT starts paused
- hitting START resumes AUX tracing
- hitting STOP pauses AUX tracing

The control events are emitted in the same perf event group as the Intel PT source.

## Motivation

magic-trace currently relies on userspace snapshot/control paths for trigger-based workflows. perf's AUX pause/resume support allows tracing to be gated directly by perf events, avoiding unnecessary trace collection outside the selected region.

## Implementation

- add typed AUX actions (`start-paused`, `resume`, `pause`)
- add breakpoint-backed AUX control events
- resolve AUX range symbols using the existing ELF/runtime address path
- support both `run` and `attach`
- reject AUX ranges when stacktrace sampling is selected
- add serialization and generated-perf-argument expect tests

## Validation

- `dune build @fmt` passes locally
- `git diff --check` passes locally
- full tests cannot run on macOS because the locked dependency graph includes Linux-only Jane Street dependencies

Opening as draft to validate the full Linux build/test suite before marking ready.