### PR TITLE
Handle trigger breakpoints across process threads

### DIFF
--- a/src/process_info.ml
+++ b/src/process_info.ml
@@ -26,4 +26,27 @@ let read_all_proc_info () =
     | _ -> ())
 ;;
 
+let thread_ids_of_dir_entries entries =
+  Array.filter_map entries ~f:(fun entry ->
+    try Some (Pid.of_string entry) with
+    | _ -> None)
+  |> Array.to_list
+  |> List.sort ~compare:Pid.compare
+;;
+
+let thread_ids pid =
+  Or_error.try_with (fun () ->
+    Sys_unix.readdir [%string "/proc/%{pid#Pid}/task"] |> thread_ids_of_dir_entries)
+;;
+
+let thread_exists ~pid ~tid =
+  match Core_unix.access [%string "/proc/%{pid#Pid}/task/%{tid#Pid}"] [ `Exists ] with
+  | Ok () -> true
+  | Error _ -> false
+;;
+
+module For_testing = struct
+  let thread_ids_of_dir_entries = thread_ids_of_dir_entries
+end
+
 let cmdline_of_pid pid = Hashtbl.find state pid

--- a/src/process_info.mli
+++ b/src/process_info.mli
@@ -8,4 +8,10 @@ end
 
 val read_proc_info : Pid.t -> unit
 val read_all_proc_info : unit -> unit
+val thread_ids : Pid.t -> Pid.t list Or_error.t
+val thread_exists : pid:Pid.t -> tid:Pid.t -> bool
 val cmdline_of_pid : Pid.t -> Entry.Cmdline.t option
+
+module For_testing : sig
+  val thread_ids_of_dir_entries : string array -> Pid.t list
+end

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -417,39 +417,14 @@ module Make_commands (Backend : Backend_intf.S) = struct
            you can accidentally incur an ~8us interrupt on every call until perf disables
            your breakpoint for exceeding the hit rate limit. *)
         let single_hit = not opts.multi_snapshot in
-        let bp = Breakpoint.breakpoint_fd head_pid ~addr in
-        let bp = Or_error.ok_exn bp in
-        let fd =
-          Async_unix.Fd.create
-            Async_unix.Fd.Kind.File
-            (Breakpoint.fd bp)
-            (Info.of_string "perf breakpoint")
-        in
-        let rec read_evs snapshot_enabled =
-          match Breakpoint.next_hit bp with
-          | Some hit ->
-            if snapshot_enabled then take_snapshot_on_hit (name, hit);
-            read_evs false
-          | None -> ()
-        in
-        let interrupt = Ivar.read done_ivar in
-        let monitoring =
-          Async_unix.Fd.interruptible_every_ready_to
-            fd
-            `Read
-            ~interrupt
-            (fun () -> read_evs true)
-            ()
-        in
-        (* Yield to let the scheduler register the fd with [epoll], then enable
-           the breakpoint. This avoids a race where a single-hit breakpoint
-           fires and disables itself before [epoll] starts monitoring the fd. *)
-        let%bind.Deferred () = Scheduler.yield () in
-        Breakpoint.enable bp ~single_hit |> Or_error.ok_exn;
-        let%map.Deferred res = monitoring in
-        (match res with
-         | `Interrupted -> Breakpoint.destroy bp
-         | `Bad_fd | `Closed | `Unsupported -> failwith "failed to wait on breakpoint")
+        Trigger_breakpoint.Manager.monitor_process
+          ~pid:head_pid
+          ~addr
+          ~single_hit
+          ~interrupt:(Ivar.read done_ivar)
+          ~on_hit:(fun hit ->
+            if opts.multi_snapshot || not !snapshot_taken
+            then take_snapshot_on_hit (name, hit))
     in
     { Attachment.recording; done_ivar; breakpoint_done; finalize_recording }
   ;;

--- a/src/trigger_breakpoint.ml
+++ b/src/trigger_breakpoint.ml
@@ -1,0 +1,122 @@
+open! Core
+open! Async
+
+type t =
+  { breakpoint : Breakpoint.t
+  ; fd : Async_unix.Fd.t
+  }
+
+let create ~tid ~addr =
+  let open Or_error.Let_syntax in
+  let%map breakpoint = Breakpoint.breakpoint_fd tid ~addr in
+  let fd =
+    Async_unix.Fd.create
+      Async_unix.Fd.Kind.File
+      (Breakpoint.fd breakpoint)
+      (Info.of_string [%string "perf breakpoint %{tid#Pid}"])
+  in
+  { breakpoint; fd }
+;;
+
+let enable t ~single_hit = Breakpoint.enable t.breakpoint ~single_hit
+
+let monitor t ~interrupt ~on_hit =
+  let rec read_events snapshot_enabled =
+    match Breakpoint.next_hit t.breakpoint with
+    | Some hit ->
+      if snapshot_enabled then on_hit hit;
+      read_events false
+    | None -> ()
+  in
+  Async_unix.Fd.interruptible_every_ready_to
+    t.fd
+    `Read
+    ~interrupt
+    (fun () -> read_events true)
+    ()
+;;
+
+let destroy t = Breakpoint.destroy t.breakpoint
+
+type breakpoint = t
+
+module Manager = struct
+  let scan_interval = Time_ns.Span.of_ms 50.
+
+  let new_thread_ids ~active tids =
+    List.filter tids ~f:(fun tid -> not (Set.mem active tid))
+  ;;
+
+  module Active_breakpoint = struct
+    type t =
+      { breakpoint : breakpoint
+      ; monitoring : unit Deferred.t
+      }
+  end
+
+  let monitor_process ~pid ~addr ~single_hit ~interrupt ~on_hit =
+    let breakpoints = Hashtbl.create (module Pid) in
+    let stopped () = Deferred.is_determined interrupt in
+    let add_tid tid =
+      if Hashtbl.mem breakpoints tid || stopped ()
+      then Deferred.unit
+      else (
+        match create ~tid ~addr with
+        | Error error ->
+          if Process_info.thread_exists ~pid ~tid
+          then Error.raise error
+          else
+            (* The task exited between /proc enumeration and perf_event_open. *)
+            Deferred.unit
+        | Ok breakpoint ->
+          let monitoring =
+            let%map result = monitor breakpoint ~interrupt ~on_hit in
+            Hashtbl.remove breakpoints tid;
+            destroy breakpoint;
+            match result with
+            | `Interrupted | `Bad_fd | `Closed -> ()
+            | `Unsupported -> failwith "failed to wait on breakpoint"
+          in
+          Hashtbl.set
+            breakpoints
+            ~key:tid
+            ~data:{ Active_breakpoint.breakpoint; monitoring };
+          let%bind () = Scheduler.yield () in
+          (match enable breakpoint ~single_hit with
+           | Ok () ->
+             don't_wait_for monitoring;
+             Deferred.unit
+           | Error error ->
+             Hashtbl.remove breakpoints tid;
+             destroy breakpoint;
+             if Process_info.thread_exists ~pid ~tid
+             then Error.raise error
+             else Deferred.unit))
+    in
+    let rec rescan () =
+      if stopped ()
+      then Deferred.unit
+      else (
+        let%bind () =
+          match Process_info.thread_ids pid with
+          | Error _ -> Deferred.unit
+          | Ok tids ->
+            let active = Hashtbl.keys breakpoints |> Set.of_list (module Pid) in
+            let new_tids = new_thread_ids ~active tids in
+            Deferred.List.iter new_tids ~how:`Sequential ~f:add_tid
+        in
+        let%bind () = Async.Clock_ns.after scan_interval in
+        rescan ())
+    in
+    let%bind () = rescan () in
+    let active =
+      Hashtbl.data breakpoints
+      |> List.map ~f:(fun { Active_breakpoint.monitoring; _ } -> monitoring)
+    in
+    Deferred.all_unit active
+  ;;
+
+  module For_testing = struct
+    let new_thread_ids = new_thread_ids
+  end
+end

--- a/src/trigger_breakpoint.mli
+++ b/src/trigger_breakpoint.mli
@@ -1,0 +1,29 @@
+open! Core
+open! Async
+
+type t
+
+val create : tid:Pid.t -> addr:int64 -> t Or_error.t
+val enable : t -> single_hit:bool -> unit Or_error.t
+
+val monitor
+  :  t
+  -> interrupt:unit Deferred.t
+  -> on_hit:(Breakpoint.Hit.t -> unit)
+  -> [ `Bad_fd | `Closed | `Interrupted | `Unsupported ] Deferred.t
+
+val destroy : t -> unit
+
+module Manager : sig
+  val monitor_process
+    :  pid:Pid.t
+    -> addr:int64
+    -> single_hit:bool
+    -> interrupt:unit Deferred.t
+    -> on_hit:(Breakpoint.Hit.t -> unit)
+    -> unit Deferred.t
+
+  module For_testing : sig
+    val new_thread_ids : active:Set.M(Pid).t -> Pid.t list -> Pid.t list
+  end
+end

--- a/test/sample-targets/multithread-trigger/dune
+++ b/test/sample-targets/multithread-trigger/dune
@@ -1,0 +1,17 @@
+(rule
+ (target multithread_trigger.exe)
+ (deps multithread_trigger.cc)
+ (action
+  (run
+   c++
+   -std=c++17
+   -O0
+   -g
+   -pthread
+   %{dep:multithread_trigger.cc}
+   -o
+   %{target})))
+
+(alias
+ (name runtest)
+ (deps multithread_trigger.exe))

--- a/test/sample-targets/multithread-trigger/multithread_trigger.cc
+++ b/test/sample-targets/multithread-trigger/multithread_trigger.cc
@@ -1,0 +1,26 @@
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+extern "C" {
+void __attribute__((noinline)) __attribute__((used))
+magic_trace_stop_indicator() {}
+}
+
+int main() {
+  std::cout << "ready" << std::endl;
+
+  // Give magic-trace time to attach before creating the worker thread.
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  std::thread worker([] {
+    // Keep the thread alive long enough for /proc/<pid>/task rescanning
+    // to discover it and arm a breakpoint.
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    magic_trace_stop_indicator();
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  });
+
+  worker.join();
+  return 0;
+}

--- a/test/test.ml
+++ b/test/test.ml
@@ -850,3 +850,24 @@ let%expect_test "get debug information from ELF" =
   [%expect {| |}];
   return ()
 ;;
+
+let%expect_test "parse thread IDs from proc task entries" =
+  Magic_trace_lib.Process_info.For_testing.thread_ids_of_dir_entries
+    [| "101"; "not-a-tid"; "7"; "42" |]
+  |> List.iter ~f:(fun pid -> Core.printf "%{Pid}\n" pid);
+  [%expect {|
+    7
+    42
+    101 |}]
+;;
+
+let%expect_test "trigger breakpoint manager finds newly-created threads" =
+  let active = Set.of_list (module Pid) [ Pid.of_int 10; Pid.of_int 20 ] in
+  Magic_trace_lib.Trigger_breakpoint.Manager.For_testing.new_thread_ids
+    ~active
+    [ Pid.of_int 10; Pid.of_int 20; Pid.of_int 30; Pid.of_int 40 ]
+  |> List.iter ~f:(fun pid -> Core.printf "%{Pid}\n" pid);
+  [%expect {|
+    30
+    40 |}]
+;;


### PR DESCRIPTION
## Summary

Fix trigger breakpoints so they can fire from worker threads when magic-trace is attached to a multithreaded process.

Fixes #274.

## Problem

The existing trigger implementation creates a hardware breakpoint only for the head PID/TID. Since `perf_event_open` breakpoints are task-specific, a trigger such as `magic_trace_stop_indicator()` can work from the main thread but be missed when called from a worker thread.

## Implementation

- Enumerate process TIDs from `/proc/<pid>/task`
- Introduce a `Trigger_breakpoint` abstraction for breakpoint lifecycle and Async FD monitoring
- Maintain one trigger breakpoint per discovered TID
- Rescan for threads created after attachment
- Handle races where threads exit during breakpoint setup
- Preserve single-snapshot behavior across thread breakpoints
- Add a multithreaded regression target based on #274

## Validation

- `dune build @fmt` passes locally
- `git diff --check` passes locally
- multithreaded C++ regression target builds successfully

End-to-end perf breakpoint behavior requires Linux validation, so this is being opened as a draft.
