### PR TITLE
Keep per-thread trace timestamps monotonic

### DIFF
--- a/src/trace_writer.ml
+++ b/src/trace_writer.ml
@@ -506,6 +506,11 @@ let event_time t (event : Event.t) (thread_info : _ Thread_info.t) =
       thread_info.last_event_time
     | Some time ->
       let time = map_time t time in
+      (* perf can occasionally emit events for a thread with timestamps older than an
+         event we have already processed. Keep the writer's per-thread logical time
+         monotonic so pending-event flushing and callstack reconstruction never operate
+         over a negative time interval. *)
+      let time = Mapped_time.max time thread_info.last_event_time in
       thread_info.last_event_time <- time;
       time
   in

--- a/test/test.ml
+++ b/test/test.ml
@@ -196,6 +196,24 @@ let dump_using_file ?range_symbols events =
   return ()
 ;;
 
+let write_using_file events =
+  let%bind events = get_events_pipe ~events () in
+  let close_result = return (Ok ()) in
+  let buf = Iobuf.create ~len:500_000 in
+  let destination = Tracing_zero.Destinations.iobuf_destination buf in
+  let writer = Tracing_zero.Writer.Expert.create ~destination () in
+  write_trace_from_events
+    ~debug_info:None
+    ~trace_scope:Userspace
+    ~events_writer:None
+    ~writer:(Some writer)
+    ~hits:[]
+    ~events:[ events ]
+    ~close_result
+    ~collection_mode:(Intel_processor_trace { extra_events = [] })
+    ()
+;;
+
 let%expect_test "random perfs" =
   let open Trace_helpers in
   let%bind.With _dirname = Expect_test_helpers_async.within_temp_dir in
@@ -849,4 +867,17 @@ let%expect_test "get debug information from ELF" =
   Expect_test_helpers_base.require_equal (module Int) raise_after_col 22;
   [%expect {| |}];
   return ()
+;;
+
+let%expect_test "trace writer handles per-thread timestamps that move backwards" =
+  let open Trace_helpers in
+  start_recording ();
+  add Call 200 "outer";
+  add Call 300 "inner";
+  add Return 150 "inner";
+  let events = events () in
+  let%map result = write_using_file events in
+  Or_error.ok_exn result;
+  print_endline "ok";
+  [%expect {| ok |}]
 ;;


### PR DESCRIPTION
## Summary

Prevent backwards per-thread event timestamps from producing invalid trace durations during decoding.

Fixes #319.

## Problem

The streaming trace writer assumes that event time for a given thread is monotonic, but that invariant was not enforced.

When an event arrives with a timestamp older than one already processed for the same thread:

- `last_event_time` moves backwards
- pending-event flushing can operate over a negative time interval
- open callstack frames can later be closed at a timestamp earlier than their start

This can ultimately produce errors such as:

`duration_complete event must have start tick (...) greater than end tick (...)`

## Implementation

Normalize incoming per-thread event timestamps at the `event_time` boundary:

- preserve stream processing order
- keep the writer's logical per-thread time monotonic
- prevent pending-event flushing from operating over negative intervals
- keep callstack reconstruction and thread-end timestamps on the same ordered timeline

The fix intentionally lives at timestamp normalization rather than clamping individual duration writes.

## Tests

Added a deterministic regression case with:

- call at 200 ns
- nested call at 300 ns
- return event at 150 ns

The trace writer must serialize this stream successfully instead of producing an invalid backwards duration.

## Validation

- `dune build @fmt` passes locally
- `git diff --check` passes locally
- full inline tests cannot currently run in the local macOS switch because Jane Street test-only dependencies are unavailable there

Opening as draft pending upstream Linux CI validation.